### PR TITLE
#30 ktlint 룰 config 수정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@
 root = true
 
 [*.{kt,kts}]
+ktlint_standard_annotation = disabled
 ktlint_function_naming_ignore_when_annotated_with = Composable
 import-ordering = false
 

--- a/core/src/main/java/com/dpm/sixpack/core/util/ConnectivityManagerNetworkMonitor.kt
+++ b/core/src/main/java/com/dpm/sixpack/core/util/ConnectivityManagerNetworkMonitor.kt
@@ -20,58 +20,56 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
-internal class ConnectivityManagerNetworkMonitor
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-        @Dispatcher(SixPackDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
-    ) : NetworkMonitor {
-        override val isOnline: Flow<Boolean> =
-            callbackFlow {
-                val connectivityManager = context.getSystemService<ConnectivityManager>()
-                if (connectivityManager == null) {
-                    channel.trySend(false)
-                    channel.close()
-                    return@callbackFlow
-                }
+internal class ConnectivityManagerNetworkMonitor @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @Dispatcher(SixPackDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : NetworkMonitor {
+    override val isOnline: Flow<Boolean> =
+        callbackFlow {
+            val connectivityManager = context.getSystemService<ConnectivityManager>()
+            if (connectivityManager == null) {
+                channel.trySend(false)
+                channel.close()
+                return@callbackFlow
+            }
 
-                val callback =
-                    object : NetworkCallback() {
-                        private val networks = mutableSetOf<Network>()
+            val callback =
+                object : NetworkCallback() {
+                    private val networks = mutableSetOf<Network>()
 
-                        override fun onAvailable(network: Network) {
-                            networks += network
-                            channel.trySend(true)
-                        }
-
-                        override fun onLost(network: Network) {
-                            networks -= network
-                            channel.trySend(networks.isNotEmpty())
-                        }
+                    override fun onAvailable(network: Network) {
+                        networks += network
+                        channel.trySend(true)
                     }
 
-                val request =
-                    Builder()
-                        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                        .build()
-                connectivityManager.registerNetworkCallback(request, callback)
-
-                channel.trySend(connectivityManager.isCurrentlyConnected())
-
-                awaitClose {
-                    connectivityManager.unregisterNetworkCallback(callback)
+                    override fun onLost(network: Network) {
+                        networks -= network
+                        channel.trySend(networks.isNotEmpty())
+                    }
                 }
-            }.flowOn(ioDispatcher)
-                .conflate()
 
-        @Suppress("DEPRECATION")
-        private fun ConnectivityManager.isCurrentlyConnected() =
-            when {
-                VERSION.SDK_INT >= VERSION_CODES.M ->
-                    activeNetwork
-                        ?.let(::getNetworkCapabilities)
-                        ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            val request =
+                Builder()
+                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    .build()
+            connectivityManager.registerNetworkCallback(request, callback)
 
-                else -> activeNetworkInfo?.isConnected
-            } ?: false
-    }
+            channel.trySend(connectivityManager.isCurrentlyConnected())
+
+            awaitClose {
+                connectivityManager.unregisterNetworkCallback(callback)
+            }
+        }.flowOn(ioDispatcher)
+            .conflate()
+
+    @Suppress("DEPRECATION")
+    private fun ConnectivityManager.isCurrentlyConnected() =
+        when {
+            VERSION.SDK_INT >= VERSION_CODES.M ->
+                activeNetwork
+                    ?.let(::getNetworkCapabilities)
+                    ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+
+            else -> activeNetworkInfo?.isConnected
+        } ?: false
+}

--- a/core/src/main/java/com/dpm/sixpack/core/util/TimeZoneMonitor.kt
+++ b/core/src/main/java/com/dpm/sixpack/core/util/TimeZoneMonitor.kt
@@ -35,57 +35,55 @@ interface TimeZoneMonitor {
 }
 
 @Singleton
-internal class TimeZoneBroadcastMonitor
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-        @ApplicationScope appScope: CoroutineScope,
-        @Dispatcher(SixPackDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
-    ) : TimeZoneMonitor {
-        override val currentTimeZone: SharedFlow<TimeZone> =
-            callbackFlow {
-                // Send the default time zone first.
-                trySend(TimeZone.currentSystemDefault())
+internal class TimeZoneBroadcastMonitor @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @ApplicationScope appScope: CoroutineScope,
+    @Dispatcher(SixPackDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : TimeZoneMonitor {
+    override val currentTimeZone: SharedFlow<TimeZone> =
+        callbackFlow {
+            // Send the default time zone first.
+            trySend(TimeZone.currentSystemDefault())
 
-                // Registers BroadcastReceiver for the TimeZone changes
-                val receiver =
-                    object : BroadcastReceiver() {
-                        override fun onReceive(
-                            context: Context,
-                            intent: Intent,
-                        ) {
-                            if (intent.action != Intent.ACTION_TIMEZONE_CHANGED) return
+            // Registers BroadcastReceiver for the TimeZone changes
+            val receiver =
+                object : BroadcastReceiver() {
+                    override fun onReceive(
+                        context: Context,
+                        intent: Intent,
+                    ) {
+                        if (intent.action != Intent.ACTION_TIMEZONE_CHANGED) return
 
-                            val zoneIdFromIntent =
-                                if (VERSION.SDK_INT < VERSION_CODES.R) {
-                                    null
-                                } else {
-                                    // Starting Android R we also get the new TimeZone.
-                                    intent.getStringExtra(Intent.EXTRA_TIMEZONE)?.let { timeZoneId ->
-                                        // We need to convert it from java.util.Timezone to java.time.ZoneId
-                                        val zoneId = ZoneId.of(timeZoneId, ZoneId.SHORT_IDS)
-                                        // Convert to kotlinx.datetime.TimeZone
-                                        zoneId.toKotlinTimeZone()
-                                    }
+                        val zoneIdFromIntent =
+                            if (VERSION.SDK_INT < VERSION_CODES.R) {
+                                null
+                            } else {
+                                // Starting Android R we also get the new TimeZone.
+                                intent.getStringExtra(Intent.EXTRA_TIMEZONE)?.let { timeZoneId ->
+                                    // We need to convert it from java.util.Timezone to java.time.ZoneId
+                                    val zoneId = ZoneId.of(timeZoneId, ZoneId.SHORT_IDS)
+                                    // Convert to kotlinx.datetime.TimeZone
+                                    zoneId.toKotlinTimeZone()
                                 }
+                            }
 
-                            // If there isn't a zoneId in the intent, fallback to the systemDefault, which should also reflect the change
-                            trySend(zoneIdFromIntent ?: TimeZone.currentSystemDefault())
-                        }
+                        // If there isn't a zoneId in the intent, fallback to the systemDefault, which should also reflect the change
+                        trySend(zoneIdFromIntent ?: TimeZone.currentSystemDefault())
                     }
-
-                // Send here again, because registering the Broadcast Receiver can take up to several milliseconds.
-                // This way, we can reduce the likelihood that a TZ change wouldn't be caught with the Broadcast Receiver.
-                trySend(TimeZone.currentSystemDefault())
-
-                awaitClose {
-                    context.unregisterReceiver(receiver)
                 }
+
+            // Send here again, because registering the Broadcast Receiver can take up to several milliseconds.
+            // This way, we can reduce the likelihood that a TZ change wouldn't be caught with the Broadcast Receiver.
+            trySend(TimeZone.currentSystemDefault())
+
+            awaitClose {
+                context.unregisterReceiver(receiver)
             }
-                // We use to prevent multiple emissions of the same type, because we use trySend multiple times.
-                .distinctUntilChanged()
-                .conflate()
-                .flowOn(ioDispatcher)
-                // Sharing the callback to prevent multiple BroadcastReceivers being registered
-                .shareIn(appScope, SharingStarted.WhileSubscribed(5_000), 1)
-    }
+        }
+            // We use to prevent multiple emissions of the same type, because we use trySend multiple times.
+            .distinctUntilChanged()
+            .conflate()
+            .flowOn(ioDispatcher)
+            // Sharing the callback to prevent multiple BroadcastReceivers being registered
+            .shareIn(appScope, SharingStarted.WhileSubscribed(5_000), 1)
+}

--- a/data/src/main/java/com/dpm/sixpack/data/repository/GpsRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/GpsRepositoryImpl.kt
@@ -10,19 +10,17 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class GpsRepositoryImpl
-    @Inject
-    constructor(
-        private val locationDataSource: LocationDataSource,
-    ) : GpsRepository {
-        override fun getLocationFlow(): Flow<DoRunResult<Location>> =
-            locationDataSource
-                .getLocationFlow()
-                .map { location ->
-                    DoRunResult.Success(location)
-                }.catch { throwable ->
-                    DoRunResult.Failure(
-                        DoRunException.DataError(throwable.message ?: " repository : location 정보가 존재하지않습니다."),
-                    )
-                }
-    }
+class GpsRepositoryImpl @Inject constructor(
+    private val locationDataSource: LocationDataSource,
+) : GpsRepository {
+    override fun getLocationFlow(): Flow<DoRunResult<Location>> =
+        locationDataSource
+            .getLocationFlow()
+            .map { location ->
+                DoRunResult.Success(location)
+            }.catch { throwable ->
+                DoRunResult.Failure(
+                    DoRunException.DataError(throwable.message ?: " repository : location 정보가 존재하지않습니다."),
+                )
+            }
+}

--- a/data/src/main/java/com/dpm/sixpack/data/repository/RunningGoalRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/RunningGoalRepositoryImpl.kt
@@ -9,23 +9,21 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class RunningGoalRepositoryImpl
-    @Inject
-    constructor(
-        private val runningGoalDataSource: RunningGoalDataSource,
-    ) : RunningGoalRepository {
-        override suspend fun getTodayRunningGoal(): DoRunResult<RunningGoal> =
-            withContext(Dispatchers.IO) {
-                try {
-                    val response = runningGoalDataSource.getTodayRunningGoal()
+class RunningGoalRepositoryImpl @Inject constructor(
+    private val runningGoalDataSource: RunningGoalDataSource,
+) : RunningGoalRepository {
+    override suspend fun getTodayRunningGoal(): DoRunResult<RunningGoal> =
+        withContext(Dispatchers.IO) {
+            try {
+                val response = runningGoalDataSource.getTodayRunningGoal()
 
-                    val runningGoal =
-                        response.data?.toRunningGoal()
-                            ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
+                val runningGoal =
+                    response.data?.toRunningGoal()
+                        ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
 
-                    DoRunResult.Success(runningGoal)
-                } catch (e: Exception) {
-                    DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
-                }
+                DoRunResult.Success(runningGoal)
+            } catch (e: Exception) {
+                DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
             }
-    }
+        }
+}

--- a/data/src/main/java/com/dpm/sixpack/data/repository/RunningRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/RunningRepositoryImpl.kt
@@ -7,47 +7,45 @@ import com.dpm.sixpack.domain.repository.RunningRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class RunningRepositoryImpl
-    @Inject
-    constructor(
-        private val dataSource: LocalRunningDataSource,
-    ) : RunningRepository {
-        override fun startNewCourse(): Long {
-            TODO("Not yet implemented")
-        }
-
-        override fun addLocationToCourse(
-            courseId: Long,
-            simpleLocation: SimpleLocation,
-            timestamp: Long,
-        ) {
-            TODO("Not yet implemented")
-        }
-
-        override fun updateCourseDistance(
-            courseId: Long,
-            distance: Double,
-        ) {
-            TODO("Not yet implemented")
-        }
-
-        override fun saveRunSession(
-            courseId: Long,
-            startTime: Long,
-            endTime: Long,
-        ) {
-            TODO("Not yet implemented")
-        }
-
-        override fun getRunDetails(sessionId: Long): Flow<RunRecord> {
-            TODO("Not yet implemented")
-        }
-
-        override fun getAllRunSession(): Flow<List<RunRecord>> {
-            TODO("Not yet implemented")
-        }
-
-        override fun deleteRun(sessionId: Long) {
-            TODO("Not yet implemented")
-        }
+class RunningRepositoryImpl @Inject constructor(
+    private val dataSource: LocalRunningDataSource,
+) : RunningRepository {
+    override fun startNewCourse(): Long {
+        TODO("Not yet implemented")
     }
+
+    override fun addLocationToCourse(
+        courseId: Long,
+        simpleLocation: SimpleLocation,
+        timestamp: Long,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateCourseDistance(
+        courseId: Long,
+        distance: Double,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun saveRunSession(
+        courseId: Long,
+        startTime: Long,
+        endTime: Long,
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRunDetails(sessionId: Long): Flow<RunRecord> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllRunSession(): Flow<List<RunRecord>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteRun(sessionId: Long) {
+        TODO("Not yet implemented")
+    }
+}

--- a/data/src/main/java/com/dpm/sixpack/data/repository/RunningSessionRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/RunningSessionRepositoryImpl.kt
@@ -23,121 +23,147 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
 
-class RunningSessionRepositoryImpl
-    @Inject
-    constructor(
-        private val runningSessionDataSource: RunningSessionDataSource,
-        private val userPreferenceRepository: UserPreferenceRepository,
-    ) : RunningSessionRepository {
-        override suspend fun start(goalPlanId: Long): DoRunResult<Long> =
-            withContext(Dispatchers.IO) {
-                val localSessionId = userPreferenceRepository.getSessionId()
-                if (localSessionId == null) {
-                    try {
-                        val response =
-                            runningSessionDataSource.postStartRunning(StartRunningRequestDto(goalPlanId))
+class RunningSessionRepositoryImpl @Inject constructor(
+    private val runningSessionDataSource: RunningSessionDataSource,
+    private val userPreferenceRepository: UserPreferenceRepository,
+) : RunningSessionRepository {
+    override suspend fun start(goalPlanId: Long): DoRunResult<Long> =
+        withContext(Dispatchers.IO) {
+            val localSessionId = userPreferenceRepository.getSessionId()
+            if (localSessionId == null) {
+                try {
+                    val response =
+                        runningSessionDataSource.postStartRunning(StartRunningRequestDto(goalPlanId))
 
-                        val sessionId =
-                            response.data?.sessionId
-                                ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
+                    val sessionId =
+                        response.data?.sessionId
+                            ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
 
-                        userPreferenceRepository.updateSessionId(sessionId) // localSessionId 업데이트
+                    userPreferenceRepository.updateSessionId(sessionId) // localSessionId 업데이트
 
-                        DoRunResult.Success(sessionId)
-                    } catch (e: Exception) {
-                        DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
-                    }
-                } else {
-                    Timber.d("local에 sessionId가 존재합니다. localData를 호출합니다.")
-                    DoRunResult.Success(localSessionId)
+                    DoRunResult.Success(sessionId)
+                } catch (e: Exception) {
+                    DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
                 }
+            } else {
+                Timber.d("local에 sessionId가 존재합니다. localData를 호출합니다.")
+                DoRunResult.Success(localSessionId)
             }
-
-        override fun getRealtimeData(): Flow<DoRunResult<RealtimeRunningData>> =
-            flow {
-                // 서울 시청 근처
-                var lat = 37.5665
-                var lon = 126.9780
-                var bearingDeg = 45.0 // 진행 방향(도)
-                var speed = 0.0f // m/s
-                var totalDistance = 0f // m
-                var durationSec = 0 // s
-
-                val targetSpeed = 3.2f // m/s (약 5'12"/km)
-                val accelPerSec = 0.25f // 웜업 가속
-                val rnd = Random(System.currentTimeMillis())
-
-                while (coroutineContext.isActive) {
-                    delay(1000L)
-
-                    // 1) 속도 업데이트: 웜업(+노이즈) + 클램프
-                    if (speed < targetSpeed) speed += accelPerSec
-                    speed += (rnd.nextFloat() - 0.5f) * 0.15f // ±0.075 m/s
-                    speed = speed.coerceIn(0f, 4.5f)
-
-                    // 2) 진행 방향 살짝 흔들림
-                    bearingDeg += (rnd.nextDouble() - 0.5) * 4.0 // ±2도
-                    val bearingRad = Math.toRadians(bearingDeg)
-
-                    // 3) 1초 이동 벡터(m)
-                    val dt = 1.0
-                    val dist = speed * dt.toFloat() // m
-                    val dNorth = dist * cos(bearingRad).toFloat()
-                    val dEast = dist * sin(bearingRad).toFloat()
-
-                    // 4) m → deg 변환
-                    val latRad = Math.toRadians(lat)
-                    val dLatDeg = dNorth / 111_320.0
-                    val dLonDeg = dEast / (111_320.0 * cos(latRad))
-
-                    // 5) 좌표 갱신
-                    lat += dLatDeg
-                    lon += dLonDeg
-
-                    // 6) 거리 적산(좌표 기반)
-                    totalDistance += dist
-
-                    // 7) 케이던스(속도 연동) - 보폭(개인 편차 + 노이즈)
-                    val baseStepLen = 1.0 + (rnd.nextDouble() - 0.5) * 0.2 // 0.9~1.1 m/step
-                    val cadence =
-                        if (speed > 0.2f) {
-                            val spm = (speed / baseStepLen) * 60.0
-                            spm.coerceIn(140.0, 190.0).toInt() // 현실 범위
-                        } else {
-                            0
-                        }
-
-                    // 8) 페이스(sec/km)
-                    val pace = if (speed > 0.3f) (1000.0 / speed).toInt() else 0
-
-                    // 9) 해발/잔노이즈
-                    val altitude = 25.0 + (rnd.nextDouble() - 0.5) * 0.8
-
-                    val data =
-                        RealtimeRunningData(
-                            latitude = lat,
-                            longitude = lon,
-                            altitude = altitude,
-                            speed = speed, // m/s (API 보낼 땐 km/h로 변환!)
-                            pace = pace, // sec/km
-                            cadence = cadence, // spm
-                            totalDistanceMeter = totalDistance,
-                            timestamp = System.currentTimeMillis(),
-                            duration = durationSec++, // 누적 러닝 시간(초)
-                        )
-
-                    emit(DoRunResult.Success(data))
-                }
-            }
-
-        override suspend fun saveRealtimeData(
-            data: RealtimeRunningData,
-        ): DoRunResult<SaveRealtimeRunningDataResult.LocalResult> {
-            TODO("Not yet implemented")
         }
 
-        override suspend fun saveSegmentData(): DoRunResult<SaveRealtimeRunningDataResult.SyncResult> =
-            withContext(Dispatchers.IO) {
+    override fun getRealtimeData(): Flow<DoRunResult<RealtimeRunningData>> =
+        flow {
+            // 서울 시청 근처
+            var lat = 37.5665
+            var lon = 126.9780
+            var bearingDeg = 45.0 // 진행 방향(도)
+            var speed = 0.0f // m/s
+            var totalDistance = 0f // m
+            var durationSec = 0 // s
+
+            val targetSpeed = 3.2f // m/s (약 5'12"/km)
+            val accelPerSec = 0.25f // 웜업 가속
+            val rnd = Random(System.currentTimeMillis())
+
+            while (coroutineContext.isActive) {
+                delay(1000L)
+
+                // 1) 속도 업데이트: 웜업(+노이즈) + 클램프
+                if (speed < targetSpeed) speed += accelPerSec
+                speed += (rnd.nextFloat() - 0.5f) * 0.15f // ±0.075 m/s
+                speed = speed.coerceIn(0f, 4.5f)
+
+                // 2) 진행 방향 살짝 흔들림
+                bearingDeg += (rnd.nextDouble() - 0.5) * 4.0 // ±2도
+                val bearingRad = Math.toRadians(bearingDeg)
+
+                // 3) 1초 이동 벡터(m)
+                val dt = 1.0
+                val dist = speed * dt.toFloat() // m
+                val dNorth = dist * cos(bearingRad).toFloat()
+                val dEast = dist * sin(bearingRad).toFloat()
+
+                // 4) m → deg 변환
+                val latRad = Math.toRadians(lat)
+                val dLatDeg = dNorth / 111_320.0
+                val dLonDeg = dEast / (111_320.0 * cos(latRad))
+
+                // 5) 좌표 갱신
+                lat += dLatDeg
+                lon += dLonDeg
+
+                // 6) 거리 적산(좌표 기반)
+                totalDistance += dist
+
+                // 7) 케이던스(속도 연동) - 보폭(개인 편차 + 노이즈)
+                val baseStepLen = 1.0 + (rnd.nextDouble() - 0.5) * 0.2 // 0.9~1.1 m/step
+                val cadence =
+                    if (speed > 0.2f) {
+                        val spm = (speed / baseStepLen) * 60.0
+                        spm.coerceIn(140.0, 190.0).toInt() // 현실 범위
+                    } else {
+                        0
+                    }
+
+                // 8) 페이스(sec/km)
+                val pace = if (speed > 0.3f) (1000.0 / speed).toInt() else 0
+
+                // 9) 해발/잔노이즈
+                val altitude = 25.0 + (rnd.nextDouble() - 0.5) * 0.8
+
+                val data =
+                    RealtimeRunningData(
+                        latitude = lat,
+                        longitude = lon,
+                        altitude = altitude,
+                        speed = speed, // m/s (API 보낼 땐 km/h로 변환!)
+                        pace = pace, // sec/km
+                        cadence = cadence, // spm
+                        totalDistanceMeter = totalDistance,
+                        timestamp = System.currentTimeMillis(),
+                        duration = durationSec++, // 누적 러닝 시간(초)
+                    )
+
+                emit(DoRunResult.Success(data))
+            }
+        }
+
+    override suspend fun saveRealtimeData(
+        data: RealtimeRunningData,
+    ): DoRunResult<SaveRealtimeRunningDataResult.LocalResult> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun saveSegmentData(): DoRunResult<SaveRealtimeRunningDataResult.SyncResult> =
+        withContext(Dispatchers.IO) {
+            val sessionId = userPreferenceRepository.getSessionId()
+
+            if (sessionId == null) {
+                return@withContext DoRunResult.Failure(
+                    DoRunException.DataError("SessionRepository : 저장된 SessionId가 존재하지 않습니다."),
+                )
+            }
+
+            try {
+                val response =
+                    runningSessionDataSource.postSegmentData(
+                        sessionId,
+                        MockRequestDataFactory.createMockSaveSegmentRequest(),
+                    )
+
+                val syncResult =
+                    response.data?.toSyncResult()
+                        ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
+
+                DoRunResult.Success(syncResult)
+            } catch (e: Exception) {
+                DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
+            }
+        }
+
+    override suspend fun finish(): DoRunResult<RunningSessionResult> =
+        withContext(Dispatchers.IO) {
+            try {
                 val sessionId = userPreferenceRepository.getSessionId()
 
                 if (sessionId == null) {
@@ -145,48 +171,20 @@ class RunningSessionRepositoryImpl
                         DoRunException.DataError("SessionRepository : 저장된 SessionId가 존재하지 않습니다."),
                     )
                 }
+                val response =
+                    runningSessionDataSource.postFinishRunning(
+                        sessionId,
+                        MockRequestDataFactory.createMockFinishRunningRequest(),
+                    )
 
-                try {
-                    val response =
-                        runningSessionDataSource.postSegmentData(
-                            sessionId,
-                            MockRequestDataFactory.createMockSaveSegmentRequest(),
-                        )
+                val runningSessionResult =
+                    response.data?.toRunningSessionResult()
+                        ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
 
-                    val syncResult =
-                        response.data?.toSyncResult()
-                            ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
-
-                    DoRunResult.Success(syncResult)
-                } catch (e: Exception) {
-                    DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
-                }
+                userPreferenceRepository.clearSessionId()
+                DoRunResult.Success(runningSessionResult)
+            } catch (e: Exception) {
+                DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
             }
-
-        override suspend fun finish(): DoRunResult<RunningSessionResult> =
-            withContext(Dispatchers.IO) {
-                try {
-                    val sessionId = userPreferenceRepository.getSessionId()
-
-                    if (sessionId == null) {
-                        return@withContext DoRunResult.Failure(
-                            DoRunException.DataError("SessionRepository : 저장된 SessionId가 존재하지 않습니다."),
-                        )
-                    }
-                    val response =
-                        runningSessionDataSource.postFinishRunning(
-                            sessionId,
-                            MockRequestDataFactory.createMockFinishRunningRequest(),
-                        )
-
-                    val runningSessionResult =
-                        response.data?.toRunningSessionResult()
-                            ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
-
-                    userPreferenceRepository.clearSessionId()
-                    DoRunResult.Success(runningSessionResult)
-                } catch (e: Exception) {
-                    DoRunResult.Failure(DoRunException.DataError("네트워크 요청에 실패했습니다: ${e.message}"))
-                }
-            }
-    }
+        }
+}

--- a/data/src/main/java/com/dpm/sixpack/data/repository/SensorRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/SensorRepositoryImpl.kt
@@ -9,21 +9,19 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class SensorRepositoryImpl
-    @Inject
-    constructor(
-        private val sensorDataSource: SensorDataSource,
-    ) : SensorRepository {
-        override fun getTotalStep(): Flow<DoRunResult<Long>> =
-            sensorDataSource
-                .getTotalStepsFlow()
-                .map { stepCount ->
-                    DoRunResult.Success(stepCount)
-                }.catch { throwable ->
-                    DoRunResult.Failure(
-                        DoRunException.DataError(
-                            throwable.message ?: " repository : totalStep이 존재하지 않습니다.",
-                        ),
-                    )
-                }
-    }
+class SensorRepositoryImpl @Inject constructor(
+    private val sensorDataSource: SensorDataSource,
+) : SensorRepository {
+    override fun getTotalStep(): Flow<DoRunResult<Long>> =
+        sensorDataSource
+            .getTotalStepsFlow()
+            .map { stepCount ->
+                DoRunResult.Success(stepCount)
+            }.catch { throwable ->
+                DoRunResult.Failure(
+                    DoRunException.DataError(
+                        throwable.message ?: " repository : totalStep이 존재하지 않습니다.",
+                    ),
+                )
+            }
+}

--- a/data/src/main/java/com/dpm/sixpack/data/repository/UserPreferenceRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/UserPreferenceRepositoryImpl.kt
@@ -6,27 +6,25 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
 
-class UserPreferenceRepositoryImpl
-    @Inject
-    constructor(
-        private val userPreferenceDataSource: UserPreferenceDataSource,
-    ) : UserPreferenceRepository {
-        private val userId = userPreferenceDataSource.userId
-        private val sessionId = userPreferenceDataSource.sessionId
+class UserPreferenceRepositoryImpl @Inject constructor(
+    private val userPreferenceDataSource: UserPreferenceDataSource,
+) : UserPreferenceRepository {
+    private val userId = userPreferenceDataSource.userId
+    private val sessionId = userPreferenceDataSource.sessionId
 
-        override suspend fun getUserId(): Long = userId.first()
+    override suspend fun getUserId(): Long = userId.first()
 
-        override suspend fun getSessionId(): Long? = sessionId.firstOrNull()
+    override suspend fun getSessionId(): Long? = sessionId.firstOrNull()
 
-        override suspend fun updateUserId(userId: Long) {
-            userPreferenceDataSource.updateUserId(userId = userId)
-        }
-
-        override suspend fun updateSessionId(sessionId: Long) {
-            userPreferenceDataSource.updateSessionId(sessionId = sessionId)
-        }
-
-        override suspend fun clearSessionId() {
-            userPreferenceDataSource.clearSessionId()
-        }
+    override suspend fun updateUserId(userId: Long) {
+        userPreferenceDataSource.updateUserId(userId = userId)
     }
+
+    override suspend fun updateSessionId(sessionId: Long) {
+        userPreferenceDataSource.updateSessionId(sessionId = sessionId)
+    }
+
+    override suspend fun clearSessionId() {
+        userPreferenceDataSource.clearSessionId()
+    }
+}

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/FetchRunningDataUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/FetchRunningDataUseCase.kt
@@ -2,12 +2,10 @@ package com.dpm.sixpack.domain.usecase
 
 import javax.inject.Inject
 
-class FetchRunningDataUseCase
-    @Inject
-    constructor(
+class FetchRunningDataUseCase @Inject constructor(
 //    private val repository: RunningServiceRepository,
-    ) {
-        operator fun invoke() {
-            // TODO: Implement the logic to fetch running data
-        }
+) {
+    operator fun invoke() {
+        // TODO: Implement the logic to fetch running data
     }
+}

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/FinishRunningSessionUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/FinishRunningSessionUseCase.kt
@@ -5,10 +5,8 @@ import com.dpm.sixpack.domain.repository.RunningSessionRepository
 import com.dpm.sixpack.domain.util.DoRunResult
 import javax.inject.Inject
 
-class FinishRunningSessionUseCase
-    @Inject
-    constructor(
-        private val repository: RunningSessionRepository,
-    ) {
-        suspend operator fun invoke(): DoRunResult<RunningSessionResult> = repository.finish()
-    }
+class FinishRunningSessionUseCase @Inject constructor(
+    private val repository: RunningSessionRepository,
+) {
+    suspend operator fun invoke(): DoRunResult<RunningSessionResult> = repository.finish()
+}

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/GetRealtimeRunningDataUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/GetRealtimeRunningDataUseCase.kt
@@ -15,81 +15,79 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class GetRealtimeRunningDataUseCase
-    @Inject
-    constructor(
-        private val gpsRepository: GpsRepository,
-        private val sensorRepository: SensorRepository,
-    ) {
-        operator fun invoke(): Flow<DoRunResult<RealtimeRunningData>> {
-            val durationFlow =
-                flow {
-                    var duration = 0
-                    while (true) {
-                        emit(duration)
-                        delay(1000L)
-                        duration++
-                    }
+class GetRealtimeRunningDataUseCase @Inject constructor(
+    private val gpsRepository: GpsRepository,
+    private val sensorRepository: SensorRepository,
+) {
+    operator fun invoke(): Flow<DoRunResult<RealtimeRunningData>> {
+        val durationFlow =
+            flow {
+                var duration = 0
+                while (true) {
+                    emit(duration)
+                    delay(1000L)
+                    duration++
                 }
-
-            val distanceAccumulatorFlow: Flow<Pair<Location?, Float>> =
-                gpsRepository
-                    .getLocationFlow()
-                    .scan(Pair<Location?, Float>(null, 0f)) { accumulator, locationResult ->
-                        if (locationResult is DoRunResult.Failure) {
-                            return@scan accumulator
-                        }
-                        val newLocation = (locationResult as DoRunResult.Success).data
-                        val lastLocation = accumulator.first
-                        val totalDistance = accumulator.second
-
-                        val newTotalDistance =
-                            if (lastLocation != null) {
-                                totalDistance + lastLocation.distanceTo(newLocation)
-                            } else {
-                                totalDistance
-                            }
-
-                        return@scan Pair(newLocation, newTotalDistance)
-                    }
-
-            return combine(
-                distanceAccumulatorFlow,
-                sensorRepository.getTotalStep(),
-                durationFlow,
-            ) { distanceData, stepsResult, duration ->
-
-                if (stepsResult is DoRunResult.Failure) {
-                    return@combine stepsResult
-                }
-
-                val currentLocation = distanceData.first
-                val totalDistance = distanceData.second
-                val totalSteps = (stepsResult as DoRunResult.Success).data
-
-                val speed = currentLocation?.speed ?: 0f
-
-                val pace = if (speed > 0.3f) (1000f / speed).toInt() else 0
-
-                val durationInMinutes = if (duration > 0) duration / 60.0 else 0.0
-                val cadence = if (durationInMinutes > 0) (totalSteps / durationInMinutes).toInt() else 0
-
-                val realtimeData =
-                    RealtimeRunningData(
-                        latitude = currentLocation?.latitude ?: 0.0,
-                        longitude = currentLocation?.longitude ?: 0.0,
-                        altitude = currentLocation?.altitude ?: 0.0,
-                        speed = speed,
-                        pace = pace,
-                        cadence = cadence,
-                        totalDistanceMeter = totalDistance,
-                        duration = duration,
-                        timestamp = System.currentTimeMillis(),
-                    )
-
-                DoRunResult.Success(realtimeData)
-            }.onStart {
-                emit(DoRunResult.Success(RealtimeRunningData()))
             }
+
+        val distanceAccumulatorFlow: Flow<Pair<Location?, Float>> =
+            gpsRepository
+                .getLocationFlow()
+                .scan(Pair<Location?, Float>(null, 0f)) { accumulator, locationResult ->
+                    if (locationResult is DoRunResult.Failure) {
+                        return@scan accumulator
+                    }
+                    val newLocation = (locationResult as DoRunResult.Success).data
+                    val lastLocation = accumulator.first
+                    val totalDistance = accumulator.second
+
+                    val newTotalDistance =
+                        if (lastLocation != null) {
+                            totalDistance + lastLocation.distanceTo(newLocation)
+                        } else {
+                            totalDistance
+                        }
+
+                    return@scan Pair(newLocation, newTotalDistance)
+                }
+
+        return combine(
+            distanceAccumulatorFlow,
+            sensorRepository.getTotalStep(),
+            durationFlow,
+        ) { distanceData, stepsResult, duration ->
+
+            if (stepsResult is DoRunResult.Failure) {
+                return@combine stepsResult
+            }
+
+            val currentLocation = distanceData.first
+            val totalDistance = distanceData.second
+            val totalSteps = (stepsResult as DoRunResult.Success).data
+
+            val speed = currentLocation?.speed ?: 0f
+
+            val pace = if (speed > 0.3f) (1000f / speed).toInt() else 0
+
+            val durationInMinutes = if (duration > 0) duration / 60.0 else 0.0
+            val cadence = if (durationInMinutes > 0) (totalSteps / durationInMinutes).toInt() else 0
+
+            val realtimeData =
+                RealtimeRunningData(
+                    latitude = currentLocation?.latitude ?: 0.0,
+                    longitude = currentLocation?.longitude ?: 0.0,
+                    altitude = currentLocation?.altitude ?: 0.0,
+                    speed = speed,
+                    pace = pace,
+                    cadence = cadence,
+                    totalDistanceMeter = totalDistance,
+                    duration = duration,
+                    timestamp = System.currentTimeMillis(),
+                )
+
+            DoRunResult.Success(realtimeData)
+        }.onStart {
+            emit(DoRunResult.Success(RealtimeRunningData()))
         }
     }
+}

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/GetTodayRunningGoalUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/GetTodayRunningGoalUseCase.kt
@@ -5,10 +5,8 @@ import com.dpm.sixpack.domain.repository.RunningGoalRepository
 import com.dpm.sixpack.domain.util.DoRunResult
 import javax.inject.Inject
 
-class GetTodayRunningGoalUseCase
-    @Inject
-    constructor(
-        private val runningGoalRepository: RunningGoalRepository,
-    ) {
-        suspend operator fun invoke(): DoRunResult<RunningGoal> = runningGoalRepository.getTodayRunningGoal()
-    }
+class GetTodayRunningGoalUseCase @Inject constructor(
+    private val runningGoalRepository: RunningGoalRepository,
+) {
+    suspend operator fun invoke(): DoRunResult<RunningGoal> = runningGoalRepository.getTodayRunningGoal()
+}

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/SaveRealtimeRunningDataUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/SaveRealtimeRunningDataUseCase.kt
@@ -5,17 +5,15 @@ import com.dpm.sixpack.domain.repository.RunningSessionRepository
 import com.dpm.sixpack.domain.util.DoRunResult
 import javax.inject.Inject
 
-class SaveRealtimeRunningDataUseCase
-    @Inject
-    constructor(
-        private val repository: RunningSessionRepository,
-    ) {
-        suspend operator fun invoke(param: SaveRealtimeRunningDataParam): DoRunResult<SaveRealtimeRunningDataResult> =
-            when (param) {
-                is SaveRealtimeRunningDataParam.LocalParam -> repository.saveRealtimeData(data = param.data)
-                is SaveRealtimeRunningDataParam.SyncParam -> repository.saveSegmentData()
-            }
-    }
+class SaveRealtimeRunningDataUseCase @Inject constructor(
+    private val repository: RunningSessionRepository,
+) {
+    suspend operator fun invoke(param: SaveRealtimeRunningDataParam): DoRunResult<SaveRealtimeRunningDataResult> =
+        when (param) {
+            is SaveRealtimeRunningDataParam.LocalParam -> repository.saveRealtimeData(data = param.data)
+            is SaveRealtimeRunningDataParam.SyncParam -> repository.saveSegmentData()
+        }
+}
 
 sealed class SaveRealtimeRunningDataParam {
     data class LocalParam(

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/StartRunningUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/StartRunningUseCase.kt
@@ -4,10 +4,8 @@ import com.dpm.sixpack.domain.repository.RunningSessionRepository
 import com.dpm.sixpack.domain.util.DoRunResult
 import javax.inject.Inject
 
-class StartRunningUseCase
-    @Inject
-    constructor(
-        private val repository: RunningSessionRepository,
-    ) {
-        suspend operator fun invoke(goalPlanId: Long): DoRunResult<Long> = repository.start(goalPlanId)
-    }
+class StartRunningUseCase @Inject constructor(
+    private val repository: RunningSessionRepository,
+) {
+    suspend operator fun invoke(goalPlanId: Long): DoRunResult<Long> = repository.start(goalPlanId)
+}

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/RunningSessionScreenContent.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/RunningSessionScreenContent.kt
@@ -79,7 +79,7 @@ fun RunningSessionScreenContent(
         }
 
         when (uiState.sessionState) {
-            RunningSessionState.Initial -> {
+            is RunningSessionState.Initial -> {
                 InitialContent(onStartClick = {
                     onStartClick()
                 })

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/RunningSessionViewModel.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/RunningSessionViewModel.kt
@@ -28,258 +28,256 @@ import kotlin.random.Random
 import kotlin.random.nextULong
 
 @HiltViewModel
-class RunningSessionViewModel
-    @Inject
-    constructor(
-        savedStateHandle: SavedStateHandle,
-        private val startRunningUseCase: StartRunningUseCase,
-        private val getRealtimeRunningDataUseCase: GetRealtimeRunningDataUseCase,
-        private val finishRunningSessionUseCase: FinishRunningSessionUseCase,
-    ) : BaseViewModel<RunningSessionUiState, RunningSessionIntent, RunningSessionSideEffect>() {
-        // TODO replace with real data
-        val todayRunData =
-            savedStateHandle.get<RunningGoal>("key_name") ?: RunningGoal(
-                id = 0L,
-                title = "3주차 2회차 러닝",
-                distance = 15_000,
-                duration = 3_600,
-                pace = 300,
-            )
+class RunningSessionViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val startRunningUseCase: StartRunningUseCase,
+    private val getRealtimeRunningDataUseCase: GetRealtimeRunningDataUseCase,
+    private val finishRunningSessionUseCase: FinishRunningSessionUseCase,
+) : BaseViewModel<RunningSessionUiState, RunningSessionIntent, RunningSessionSideEffect>() {
+    // TODO replace with real data
+    val todayRunData =
+        savedStateHandle.get<RunningGoal>("key_name") ?: RunningGoal(
+            id = 0L,
+            title = "3주차 2회차 러닝",
+            distance = 15_000,
+            duration = 3_600,
+            pace = 300,
+        )
 
-        override val initialState: RunningSessionUiState = RunningSessionUiState()
+    override val initialState: RunningSessionUiState = RunningSessionUiState()
 
-        override val container: Container<RunningSessionUiState, RunningSessionSideEffect> =
-            container(initialState = initialState, savedStateHandle = savedStateHandle)
+    override val container: Container<RunningSessionUiState, RunningSessionSideEffect> =
+        container(initialState = initialState, savedStateHandle = savedStateHandle)
 
-        override fun onIntent(intent: RunningSessionIntent) {
-            when (intent) {
-                RunningSessionIntent.SessionStart -> handleStart()
-                RunningSessionIntent.MainRunningPause -> handlePause()
-                RunningSessionIntent.MainRunningResume -> handleResume()
-                RunningSessionIntent.MainRunningCancelFinish -> handleCancelFinish()
-                RunningSessionIntent.MainRunningFinish -> handleFinish()
-                RunningSessionIntent.MainRunningConfirmFinish -> handleConfirmFinish()
-                RunningSessionIntent.ToggleFollowingMode -> handleToggleFollowingMode()
-                else -> {
-                    // No-Op
+    override fun onIntent(intent: RunningSessionIntent) {
+        when (intent) {
+            RunningSessionIntent.SessionStart -> handleStart()
+            RunningSessionIntent.MainRunningPause -> handlePause()
+            RunningSessionIntent.MainRunningResume -> handleResume()
+            RunningSessionIntent.MainRunningCancelFinish -> handleCancelFinish()
+            RunningSessionIntent.MainRunningFinish -> handleFinish()
+            RunningSessionIntent.MainRunningConfirmFinish -> handleConfirmFinish()
+            RunningSessionIntent.ToggleFollowingMode -> handleToggleFollowingMode()
+            else -> {
+                // No-Op
+            }
+        }
+    }
+
+    private fun handleStart() {
+        viewModelScope.launch {
+            startRunningUseCase(goalPlanId = todayRunData.id)
+
+            intent {
+                var timer = 0
+                repeat(INITIAL_COUNTDOWN) {
+                    reduce {
+                        Timber.d("countdown: ${INITIAL_COUNTDOWN - timer}")
+                        state.copy(
+                            sessionState =
+                                RunningSessionState.WarmUp.Ready(
+                                    countdown = INITIAL_COUNTDOWN - timer,
+                                ),
+                        )
+                    }
+                    timer++
+                    delay(1000L)
+                }
+
+                reduce {
+                    state.copy(
+                        sessionState =
+                            RunningSessionState.Main.Running(
+                                mapUiState = MapUiState(),
+                                recordUiState = RecordUiState(),
+                            ),
+                    )
+                }
+
+                getRealtimeRunningDataUseCase()
+                    .catch { }
+                    .collect { result ->
+                        val currentState = state.sessionState
+                        val realtimeData = result.getOrNull()
+                        if (currentState is RunningSessionState.Main.Running && realtimeData != null) {
+                            val currentPaceColors =
+                                currentState.mapUiState.paceColors.lastOrNull() ?: listOf()
+                            val newPaceColors =
+                                currentPaceColors + listOf(Random.nextULong(0uL..0xFFFFFFFFuL))
+                            val currentPath =
+                                currentState.mapUiState.path.lastOrNull() ?: listOf()
+                            val newPath =
+                                currentPath +
+                                    LatLng(
+                                        realtimeData.latitude,
+                                        realtimeData.longitude,
+                                    )
+                            reduce {
+                                state.copy(
+                                    sessionState =
+                                        currentState.copy(
+                                            mapUiState =
+                                                currentState.mapUiState.copy(
+                                                    paceColors =
+                                                        currentState.mapUiState.paceColors
+                                                            .dropLast(1)
+                                                            .toMutableList()
+                                                            .apply {
+                                                                add(newPaceColors)
+                                                            },
+                                                    path =
+                                                        currentState.mapUiState.path
+                                                            .dropLast(1)
+                                                            .toMutableList()
+                                                            .apply {
+                                                                add(newPath)
+                                                            },
+                                                ),
+                                            recordUiState =
+                                                currentState.recordUiState.copy(
+                                                    currentDistance = "${realtimeData.totalDistanceMeter}m",
+                                                    currentDuration = formatSecondsToTime(realtimeData.duration),
+                                                    avgPace =
+                                                        calculatePace(
+                                                            totalTimeInSeconds = realtimeData.duration,
+                                                            distanceInKm = realtimeData.totalDistanceMeter / 1000.0,
+                                                        ),
+                                                    cadence = "${realtimeData.cadence}",
+                                                ),
+                                        ),
+                                )
+                            }
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun handlePause() {
+        intent {
+            val currentState = state.sessionState
+            if (currentState is RunningSessionState.Main.Running) {
+                reduce {
+                    state.copy(
+                        sessionState =
+                            RunningSessionState.Main.Pause(
+                                mapUiState =
+                                    currentState.mapUiState.copy(
+                                        paceColors = currentState.mapUiState.paceColors + listOf(),
+                                        path = currentState.mapUiState.path + listOf(),
+                                    ),
+                                recordUiState = currentState.recordUiState,
+                                showFinishSessionConfirmUi = false,
+                            ),
+                    )
                 }
             }
         }
+    }
 
-        private fun handleStart() {
-            viewModelScope.launch {
-                startRunningUseCase(goalPlanId = todayRunData.id)
+    private fun handleResume() {
+        intent {
+            val currentState = state.sessionState
+            if (currentState is RunningSessionState.Main.Pause) {
+                reduce {
+                    state.copy(
+                        sessionState =
+                            RunningSessionState.Main.Running(
+                                mapUiState = currentState.mapUiState,
+                                recordUiState = currentState.recordUiState,
+                            ),
+                    )
+                }
+            }
+        }
+    }
 
-                intent {
+    private fun handleCancelFinish() {
+        intent {
+            val currentState = state.sessionState
+            if (currentState is RunningSessionState.Main.Pause) {
+                reduce {
+                    state.copy(
+                        sessionState =
+                            currentState.copy(
+                                showFinishSessionConfirmUi = false,
+                            ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun handleFinish() {
+        intent {
+            val currentState = state.sessionState
+            if (currentState is RunningSessionState.Main.Pause) {
+                reduce {
+                    state.copy(
+                        sessionState =
+                            currentState.copy(
+                                showFinishSessionConfirmUi = true,
+                            ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun handleConfirmFinish() {
+        viewModelScope.launch {
+            finishRunningSessionUseCase()
+            intent {
+                val currentState = state.sessionState
+                if (currentState is RunningSessionState.Main.Pause) {
                     var timer = 0
                     repeat(INITIAL_COUNTDOWN) {
                         reduce {
-                            Timber.d("countdown: ${INITIAL_COUNTDOWN - timer}")
                             state.copy(
                                 sessionState =
                                     RunningSessionState.WarmUp.Ready(
+//                                            mapUiState = currentState.mapUiState,
                                         countdown = INITIAL_COUNTDOWN - timer,
                                     ),
                             )
                         }
                         timer++
-                        delay(1000L)
-                    }
-
-                    reduce {
-                        state.copy(
-                            sessionState =
-                                RunningSessionState.Main.Running(
-                                    mapUiState = MapUiState(),
-                                    recordUiState = RecordUiState(),
-                                ),
-                        )
-                    }
-
-                    getRealtimeRunningDataUseCase()
-                        .catch { }
-                        .collect { result ->
-                            val currentState = state.sessionState
-                            val realtimeData = result.getOrNull()
-                            if (currentState is RunningSessionState.Main.Running && realtimeData != null) {
-                                val currentPaceColors =
-                                    currentState.mapUiState.paceColors.lastOrNull() ?: listOf()
-                                val newPaceColors =
-                                    currentPaceColors + listOf(Random.nextULong(0uL..0xFFFFFFFFuL))
-                                val currentPath =
-                                    currentState.mapUiState.path.lastOrNull() ?: listOf()
-                                val newPath =
-                                    currentPath +
-                                        LatLng(
-                                            realtimeData.latitude,
-                                            realtimeData.longitude,
-                                        )
-                                reduce {
-                                    state.copy(
-                                        sessionState =
-                                            currentState.copy(
-                                                mapUiState =
-                                                    currentState.mapUiState.copy(
-                                                        paceColors =
-                                                            currentState.mapUiState.paceColors
-                                                                .dropLast(1)
-                                                                .toMutableList()
-                                                                .apply {
-                                                                    add(newPaceColors)
-                                                                },
-                                                        path =
-                                                            currentState.mapUiState.path
-                                                                .dropLast(1)
-                                                                .toMutableList()
-                                                                .apply {
-                                                                    add(newPath)
-                                                                },
-                                                    ),
-                                                recordUiState =
-                                                    currentState.recordUiState.copy(
-                                                        currentDistance = "${realtimeData.totalDistanceMeter}m",
-                                                        currentDuration = formatSecondsToTime(realtimeData.duration),
-                                                        avgPace =
-                                                            calculatePace(
-                                                                totalTimeInSeconds = realtimeData.duration,
-                                                                distanceInKm = realtimeData.totalDistanceMeter / 1000.0,
-                                                            ),
-                                                        cadence = "${realtimeData.cadence}",
-                                                    ),
-                                            ),
-                                    )
-                                }
-                            }
-                        }
-                }
-            }
-        }
-
-        private fun handlePause() {
-            intent {
-                val currentState = state.sessionState
-                if (currentState is RunningSessionState.Main.Running) {
-                    reduce {
-                        state.copy(
-                            sessionState =
-                                RunningSessionState.Main.Pause(
-                                    mapUiState =
-                                        currentState.mapUiState.copy(
-                                            paceColors = currentState.mapUiState.paceColors + listOf(),
-                                            path = currentState.mapUiState.path + listOf(),
-                                        ),
-                                    recordUiState = currentState.recordUiState,
-                                    showFinishSessionConfirmUi = false,
-                                ),
-                        )
                     }
                 }
             }
-        }
-
-        private fun handleResume() {
-            intent {
-                val currentState = state.sessionState
-                if (currentState is RunningSessionState.Main.Pause) {
-                    reduce {
-                        state.copy(
-                            sessionState =
-                                RunningSessionState.Main.Running(
-                                    mapUiState = currentState.mapUiState,
-                                    recordUiState = currentState.recordUiState,
-                                ),
-                        )
-                    }
-                }
-            }
-        }
-
-        private fun handleCancelFinish() {
-            intent {
-                val currentState = state.sessionState
-                if (currentState is RunningSessionState.Main.Pause) {
-                    reduce {
-                        state.copy(
-                            sessionState =
-                                currentState.copy(
-                                    showFinishSessionConfirmUi = false,
-                                ),
-                        )
-                    }
-                }
-            }
-        }
-
-        private fun handleFinish() {
-            intent {
-                val currentState = state.sessionState
-                if (currentState is RunningSessionState.Main.Pause) {
-                    reduce {
-                        state.copy(
-                            sessionState =
-                                currentState.copy(
-                                    showFinishSessionConfirmUi = true,
-                                ),
-                        )
-                    }
-                }
-            }
-        }
-
-        private fun handleConfirmFinish() {
-            viewModelScope.launch {
-                finishRunningSessionUseCase()
-                intent {
-                    val currentState = state.sessionState
-                    if (currentState is RunningSessionState.Main.Pause) {
-                        var timer = 0
-                        repeat(INITIAL_COUNTDOWN) {
-                            reduce {
-                                state.copy(
-                                    sessionState =
-                                        RunningSessionState.WarmUp.Ready(
-//                                            mapUiState = currentState.mapUiState,
-                                            countdown = INITIAL_COUNTDOWN - timer,
-                                        ),
-                                )
-                            }
-                            timer++
-                        }
-                    }
-                }
-            }
-        }
-
-        fun handleToggleFollowingMode() {
-            intent {
-                reduce {
-                    state.copy(
-                        isFollowingModeEnabled = !state.isFollowingModeEnabled,
-                    )
-                }
-            }
-        }
-
-        private fun formatSecondsToTime(totalSeconds: Int): String {
-            val seconds = abs(totalSeconds)
-
-            val hours = seconds / 3600
-            val minutes = (seconds % 3600) / 60
-            val remainingSeconds = seconds % 60
-
-            return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
-        }
-
-        private fun calculatePace(
-            totalTimeInSeconds: Int,
-            distanceInKm: Double,
-        ): String {
-            if (distanceInKm <= 0) return "00:00"
-
-            val paceInSeconds = (totalTimeInSeconds / distanceInKm).toInt()
-            val minutes = paceInSeconds / 60
-            val seconds = paceInSeconds % 60
-
-            return String.format("%02d'%02d", minutes, seconds)
         }
     }
+
+    fun handleToggleFollowingMode() {
+        intent {
+            reduce {
+                state.copy(
+                    isFollowingModeEnabled = !state.isFollowingModeEnabled,
+                )
+            }
+        }
+    }
+
+    private fun formatSecondsToTime(totalSeconds: Int): String {
+        val seconds = abs(totalSeconds)
+
+        val hours = seconds / 3600
+        val minutes = (seconds % 3600) / 60
+        val remainingSeconds = seconds % 60
+
+        return String.format("%02d:%02d:%02d", hours, minutes, remainingSeconds)
+    }
+
+    private fun calculatePace(
+        totalTimeInSeconds: Int,
+        distanceInKm: Double,
+    ): String {
+        if (distanceInKm <= 0) return "00:00"
+
+        val paceInSeconds = (totalTimeInSeconds / distanceInKm).toInt()
+        val minutes = paceInSeconds / 60
+        val seconds = paceInSeconds % 60
+
+        return String.format("%02d'%02d", minutes, seconds)
+    }
+}

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/component/panel/RecordGrid.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/component/panel/RecordGrid.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dpm.sixpack.presentation.R
-import com.dpm.sixpack.presentation.routes.session.contract.RecordUiState
+import com.dpm.sixpack.presentation.routes.session.contract.uistate.RecordUiState
 
 @Composable
 internal fun MainRunningRecordGrid(

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/component/panel/RecordPanel.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/session/component/panel/RecordPanel.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dpm.sixpack.presentation.R
 import com.dpm.sixpack.presentation.common.components.DoRunDefaultButton
-import com.dpm.sixpack.presentation.routes.session.contract.RecordUiState
+import com.dpm.sixpack.presentation.routes.session.contract.uistate.RecordUiState
 import com.dpm.sixpack.presentation.routes.session.contract.uistate.RunningSessionState
 import com.dpm.sixpack.presentation.theme.SixpackTheme
 


### PR DESCRIPTION
resolve #30 

## 변경 내용과 목적  
### ktlint 어노테이션 룰 수정

기존 룰에서 @Inject constructor() 를 사용해 주입받던 클래스에서

```kotlin
@HiltViewModel
class RunningSessionViewModel
    @Inject
    constructor(
        savedStateHandle: SavedStateHandle,
        private val startRunningUseCase: StartRunningUseCase,
        private val getRealtimeRunningDataUseCase: GetRealtimeRunningDataUseCase,
        private val finishRunningSessionUseCase: FinishRunningSessionUseCase,
    ) : BaseViewModel<RunningSessionUiState, RunningSessionIntent, RunningSessionSideEffect>() {
        // TODO replace with real data
        val todayRunData =
            savedStateHandle.get<RunningGoal>("key_name") ?: RunningGoal(
                id = 0L,
                title = "3주차 2회차 러닝",
                distance = 15_000,
                duration = 3_600,
                pace = 300,
            )
```
위 처럼 클래스 바디부터 들여쓰기 탭이 2번 적용되어서
읽고 쓰는데 불편함이 있었습니다.

따라서 룰을 수정합니다.

```
[*.{kt,kts}]
ktlint_standard_annotation = disabled
```

수정된 룰이 반영되어 유스케이스 등 @Inject 사용해 생성자에서 주입받던 코드들의 들여쓰기 상태가 변경되었습니다.

## 🙏 Reviewer 가 신경써서 볼만한 포인트  
