### PR TITLE
#73 인증토큰 자동추가, 갱신 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,4 +199,7 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/java,androidstudio,android,kotlin
 
+# Claude
+.claude
 CLAUDE.md
+.mcp.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.sixpack.android.application)
+    id("kotlin-parcelize")
 }
 
 android {
@@ -24,4 +25,7 @@ dependencies {
     implementation(libs.bundles.coil)
     implementation(libs.kotlinx.datetime)
     implementation(libs.androidx.core.splashscreen)
+
+    // Orbit MVI for MainViewModel
+    implementation(libs.bundles.orbit)
 }

--- a/app/src/main/java/com/dpm/sixpack/main/MainActivity.kt
+++ b/app/src/main/java/com/dpm/sixpack/main/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -14,6 +15,7 @@ import com.dpm.sixpack.LocalTimeZone
 import com.dpm.sixpack.core.util.NetworkMonitor
 import com.dpm.sixpack.core.util.TimeZoneMonitor
 import com.dpm.sixpack.main.navigation.rememberMainNavigator
+import com.dpm.sixpack.presentation.destinations.OnboardingRoute
 import com.dpm.sixpack.presentation.theme.SixpackTheme
 import com.dpm.sixpack.rememberSixPackAppState
 import dagger.hilt.android.AndroidEntryPoint
@@ -50,6 +52,21 @@ class MainActivity : ComponentActivity() {
                     )
 
                 val currentTimeZone by appState.currentTimeZone.collectAsStateWithLifecycle()
+
+                // AuthEvent 처리: 토큰 만료/갱신 실패 시 Onboarding 화면으로 이동
+                LaunchedEffect(Unit) {
+                    viewModel.container.sideEffectFlow.collect { sideEffect ->
+                        when (sideEffect) {
+                            is MainSideEffect.NavigateToOnboarding -> {
+                                // Onboarding 화면으로 이동 (백스택 전체 클리어)
+                                appState.navigator.navController.navigate(OnboardingRoute) {
+                                    // 백스택 전체 클리어
+                                    popUpTo(0) { inclusive = true }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 CompositionLocalProvider(
                     LocalTimeZone provides currentTimeZone,

--- a/app/src/main/java/com/dpm/sixpack/main/MainIntent.kt
+++ b/app/src/main/java/com/dpm/sixpack/main/MainIntent.kt
@@ -1,0 +1,8 @@
+package com.dpm.sixpack.main
+
+import com.dpm.sixpack.presentation.common.base.UiIntent
+
+/**
+ * MainViewModel의 UI Intent
+ */
+sealed interface MainIntent : UiIntent

--- a/app/src/main/java/com/dpm/sixpack/main/MainSideEffect.kt
+++ b/app/src/main/java/com/dpm/sixpack/main/MainSideEffect.kt
@@ -1,0 +1,10 @@
+package com.dpm.sixpack.main
+
+import com.dpm.sixpack.presentation.common.base.SideEffect
+
+/**
+ * MainViewModel의 Side Effect
+ */
+sealed interface MainSideEffect : SideEffect {
+    data object NavigateToOnboarding : MainSideEffect
+}

--- a/app/src/main/java/com/dpm/sixpack/main/MainState.kt
+++ b/app/src/main/java/com/dpm/sixpack/main/MainState.kt
@@ -1,0 +1,12 @@
+package com.dpm.sixpack.main
+
+import com.dpm.sixpack.presentation.common.base.UiState
+import kotlinx.parcelize.Parcelize
+
+/**
+ * MainViewModel의 UI 상태
+ */
+@Parcelize
+data class MainState(
+    val placeholder: Unit = Unit,
+) : UiState

--- a/app/src/main/java/com/dpm/sixpack/main/MainViewModel.kt
+++ b/app/src/main/java/com/dpm/sixpack/main/MainViewModel.kt
@@ -1,8 +1,10 @@
 package com.dpm.sixpack.main
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dpm.sixpack.domain.model.AuthEvent
+import com.dpm.sixpack.domain.repository.UserPreferenceRepository
 import com.dpm.sixpack.domain.usecase.CheckUserLoggedInUseCase
+import com.dpm.sixpack.presentation.common.base.BaseViewModel
 import com.dpm.sixpack.presentation.destinations.MainRoute
 import com.dpm.sixpack.presentation.destinations.OnboardingRoute
 import com.dpm.sixpack.presentation.destinations.Route
@@ -11,12 +13,21 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.viewmodel.container
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val checkUserLoggedInUseCase: CheckUserLoggedInUseCase,
-) : ViewModel() {
+    private val userPreferenceRepository: UserPreferenceRepository,
+) : BaseViewModel<MainState, MainIntent, MainSideEffect>() {
+    override val initialState: MainState = MainState()
+
+    override val container: Container<MainState, MainSideEffect> =
+        container(initialState = initialState)
+
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
@@ -25,6 +36,11 @@ class MainViewModel @Inject constructor(
 
     init {
         initializeStartDestination()
+        observeAuthEvents()
+    }
+
+    override fun onIntent(intent: MainIntent) {
+        // MainViewModel은 현재 UI Intent를 처리하지 않음
     }
 
     private fun initializeStartDestination() =
@@ -40,4 +56,29 @@ class MainViewModel @Inject constructor(
 
             _isLoading.value = false
         }
+
+    /**
+     * AuthEvent 관찰하여 토큰 만료/갱신 실패 시 Onboarding 화면으로 이동
+     */
+    private fun observeAuthEvents() {
+        viewModelScope.launch {
+            userPreferenceRepository.authEvents.collect { event ->
+                when (event) {
+                    is AuthEvent.LoggedOut -> {
+                        Timber.d("User logged out, navigating to Onboarding screen")
+                        intent { postSideEffect(MainSideEffect.NavigateToOnboarding) }
+                    }
+
+                    is AuthEvent.TokenRefreshFailed -> {
+                        Timber.e("Token refresh failed: ${event.reason}, navigating to Onboarding screen")
+                        intent { postSideEffect(MainSideEffect.NavigateToOnboarding) }
+                    }
+
+                    else -> {
+                        // Do nothing.
+                    }
+                }
+            }
+        }
+    }
 }

--- a/data/src/main/java/com/dpm/sixpack/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/AuthRepositoryImpl.kt
@@ -130,4 +130,26 @@ class AuthRepositoryImpl @Inject constructor(
                 )
             }
         }
+
+    override suspend fun refreshToken(refreshToken: String): DoRunResult<com.dpm.sixpack.domain.model.AuthToken> =
+        withContext(Dispatchers.IO) {
+            try {
+                val response = authDataSource.refreshToken(refreshToken)
+
+                val authToken =
+                    response.data?.toAuthToken()
+                        ?: throw DoRunException.DataError("서버 응답 데이터가 비어 있습니다.")
+
+                DoRunResult.Success(authToken)
+            } catch (e: DoRunException) {
+                DoRunResult.Failure(e)
+            } catch (e: Exception) {
+                DoRunResult.Failure(
+                    DoRunException.NetworkError(
+                        message = "토큰 갱신에 실패했습니다: ${e.message}",
+                        cause = e,
+                    ),
+                )
+            }
+        }
 }

--- a/data/src/main/java/com/dpm/sixpack/data/repository/UserPreferenceRepositoryImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/repository/UserPreferenceRepositoryImpl.kt
@@ -1,11 +1,17 @@
 package com.dpm.sixpack.data.repository
 
 import com.dpm.sixpack.data.source.local.datastore.api.UserPreferenceDataSource
+import com.dpm.sixpack.domain.model.AuthEvent
 import com.dpm.sixpack.domain.repository.UserPreferenceRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class UserPreferenceRepositoryImpl @Inject constructor(
     private val userPreferenceDataSource: UserPreferenceDataSource,
 ) : UserPreferenceRepository {
@@ -13,6 +19,9 @@ class UserPreferenceRepositoryImpl @Inject constructor(
     private val sessionId = userPreferenceDataSource.sessionId
     private val accessToken = userPreferenceDataSource.accessToken
     private val refreshToken = userPreferenceDataSource.refreshToken
+
+    private val _authEvents = MutableSharedFlow<AuthEvent>(replay = 0, extraBufferCapacity = 1)
+    override val authEvents: SharedFlow<AuthEvent> = _authEvents.asSharedFlow()
 
     override suspend fun getUserId(): Long = userId.first()
 
@@ -44,5 +53,11 @@ class UserPreferenceRepositoryImpl @Inject constructor(
 
     override suspend fun clearTokens() {
         userPreferenceDataSource.clearTokens()
+        // Emit LoggedOut event when tokens are cleared
+        _authEvents.tryEmit(AuthEvent.LoggedOut)
+    }
+
+    override suspend fun emitAuthEvent(event: AuthEvent) {
+        _authEvents.tryEmit(event)
     }
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/AuthDataSourceImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/AuthDataSourceImpl.kt
@@ -1,9 +1,13 @@
 package com.dpm.sixpack.data.source.remote.datasoruce
 
 import com.dpm.sixpack.data.source.remote.datasoruce.api.AuthDataSource
+import com.dpm.sixpack.data.source.remote.di.AuthRetrofit
+import com.dpm.sixpack.data.source.remote.di.RefreshRetrofit
+import com.dpm.sixpack.data.source.remote.dto.request.RefreshTokenRequestDto
 import com.dpm.sixpack.data.source.remote.dto.request.SendSmsRequestDto
 import com.dpm.sixpack.data.source.remote.dto.request.SignUpRequestDto
 import com.dpm.sixpack.data.source.remote.dto.request.VerifySmsRequestDto
+import com.dpm.sixpack.data.source.remote.dto.response.RefreshTokenResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.SignUpResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.VerifySmsResponseDto
 import com.dpm.sixpack.data.source.remote.service.AuthService
@@ -17,8 +21,14 @@ import retrofit2.Response
 import java.io.File
 import javax.inject.Inject
 
+/**
+ * AuthDataSource 구현체
+ * - 일반 API는 authService 사용 (AuthInterceptor + TokenAuthenticator 포함)
+ * - 토큰 갱신 API는 refreshAuthService 사용 (데드락 방지)
+ */
 class AuthDataSourceImpl @Inject constructor(
-    private val authService: AuthService,
+    @AuthRetrofit private val authService: AuthService,
+    @RefreshRetrofit private val refreshAuthService: AuthService,
     private val json: Json,
 ) : AuthDataSource {
     override suspend fun sendSmsCode(phoneNumber: String): Response<BaseResponse<Unit>> {
@@ -68,5 +78,17 @@ class AuthDataSourceImpl @Inject constructor(
             data = dataRequestBody,
             profileImage = imagePart,
         )
+    }
+
+    /**
+     * 토큰 갱신 API - refreshAuthService 사용 (데드락 방지)
+     * TokenAuthenticator에서 호출되므로 별도의 OkHttpClient 사용 필요
+     */
+    override suspend fun refreshToken(refreshToken: String): BaseResponse<RefreshTokenResponseDto> {
+        val requestDto =
+            RefreshTokenRequestDto(
+                refreshToken = refreshToken,
+            )
+        return refreshAuthService.refreshToken(request = requestDto)
     }
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/AuthDataSourceImpl.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/AuthDataSourceImpl.kt
@@ -1,8 +1,6 @@
 package com.dpm.sixpack.data.source.remote.datasoruce
 
 import com.dpm.sixpack.data.source.remote.datasoruce.api.AuthDataSource
-import com.dpm.sixpack.data.source.remote.di.AuthRetrofit
-import com.dpm.sixpack.data.source.remote.di.RefreshRetrofit
 import com.dpm.sixpack.data.source.remote.dto.request.RefreshTokenRequestDto
 import com.dpm.sixpack.data.source.remote.dto.request.SendSmsRequestDto
 import com.dpm.sixpack.data.source.remote.dto.request.SignUpRequestDto
@@ -21,14 +19,8 @@ import retrofit2.Response
 import java.io.File
 import javax.inject.Inject
 
-/**
- * AuthDataSource 구현체
- * - 일반 API는 authService 사용 (AuthInterceptor + TokenAuthenticator 포함)
- * - 토큰 갱신 API는 refreshAuthService 사용 (데드락 방지)
- */
 class AuthDataSourceImpl @Inject constructor(
-    @AuthRetrofit private val authService: AuthService,
-    @RefreshRetrofit private val refreshAuthService: AuthService,
+    private val authService: AuthService,
     private val json: Json,
 ) : AuthDataSource {
     override suspend fun sendSmsCode(phoneNumber: String): Response<BaseResponse<Unit>> {
@@ -80,15 +72,11 @@ class AuthDataSourceImpl @Inject constructor(
         )
     }
 
-    /**
-     * 토큰 갱신 API - refreshAuthService 사용 (데드락 방지)
-     * TokenAuthenticator에서 호출되므로 별도의 OkHttpClient 사용 필요
-     */
     override suspend fun refreshToken(refreshToken: String): BaseResponse<RefreshTokenResponseDto> {
         val requestDto =
             RefreshTokenRequestDto(
                 refreshToken = refreshToken,
             )
-        return refreshAuthService.refreshToken(request = requestDto)
+        return authService.refreshToken(request = requestDto)
     }
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/MockAuthDataSource.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/MockAuthDataSource.kt
@@ -1,6 +1,7 @@
 package com.dpm.sixpack.data.source.remote.datasoruce
 
 import com.dpm.sixpack.data.source.remote.datasoruce.api.AuthDataSource
+import com.dpm.sixpack.data.source.remote.dto.response.RefreshTokenResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.SignUpResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.TokenDto
 import com.dpm.sixpack.data.source.remote.dto.response.UserDto
@@ -91,6 +92,21 @@ class MockAuthDataSource @Inject constructor() : AuthDataSource {
                             accessToken = "mock_access_token",
                             refreshToken = "mock_refresh_token",
                         ),
+                ),
+        )
+    }
+
+    override suspend fun refreshToken(refreshToken: String): BaseResponse<RefreshTokenResponseDto> {
+        delay(500L)
+        // 토큰 갱신 성공 응답
+        return BaseResponse(
+            status = "200",
+            message = "토큰 갱신 성공",
+            timestamp = getCurrentTimestamp(),
+            data =
+                RefreshTokenResponseDto(
+                    accessToken = "mock_new_access_token_${System.currentTimeMillis()}",
+                    refreshToken = "mock_new_refresh_token_${System.currentTimeMillis()}",
                 ),
         )
     }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/api/AuthDataSource.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/api/AuthDataSource.kt
@@ -1,5 +1,6 @@
 package com.dpm.sixpack.data.source.remote.datasoruce.api
 
+import com.dpm.sixpack.data.source.remote.dto.response.RefreshTokenResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.SignUpResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.VerifySmsResponseDto
 import com.dpm.sixpack.data.source.remote.util.base.BaseResponse
@@ -19,4 +20,6 @@ interface AuthDataSource {
         phoneNumber: String,
         profileImage: File?,
     ): BaseResponse<SignUpResponseDto>
+
+    suspend fun refreshToken(refreshToken: String): BaseResponse<RefreshTokenResponseDto>
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/di/RemoteDataSourceModule.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/datasoruce/di/RemoteDataSourceModule.kt
@@ -1,6 +1,6 @@
 package com.dpm.sixpack.data.source.remote.datasoruce.di
 
-import com.dpm.sixpack.data.source.remote.datasoruce.MockAuthDataSource
+import com.dpm.sixpack.data.source.remote.datasoruce.AuthDataSourceImpl
 import com.dpm.sixpack.data.source.remote.datasoruce.api.AuthDataSource
 import dagger.Binds
 import dagger.Module
@@ -10,10 +10,9 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 @Module
 internal abstract class RemoteDataSourceModule {
-    @Binds
-    abstract fun bindsAuthDataSource(dataSource: MockAuthDataSource): AuthDataSource
+//    @Binds
+//    abstract fun bindsAuthDataSource(dataSource: MockAuthDataSource): AuthDataSource
 
-    // TODO: 서버 API 안정화 후 MockAuthDataSource → AuthDataSourceImpl로 변경
-    // @Binds
-    // abstract fun bindsAuthDataSource(dataSource: AuthDataSourceImpl): AuthDataSource
+    @Binds
+    abstract fun bindsAuthDataSource(dataSource: AuthDataSourceImpl): AuthDataSource
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/di/RetrofitModule.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/di/RetrofitModule.kt
@@ -17,22 +17,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.util.concurrent.TimeUnit
-import javax.inject.Qualifier
 import javax.inject.Singleton
-
-/**
- * 일반 API 호출용 Retrofit (AuthInterceptor + TokenAuthenticator 포함)
- */
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class AuthRetrofit
-
-/**
- * 토큰 갱신 전용 Retrofit (Authenticator 제외, 데드락 방지)
- */
-@Qualifier
-@Retention(AnnotationRetention.BINARY)
-annotation class RefreshRetrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -54,12 +39,8 @@ object RetrofitModule {
             level = HttpLoggingInterceptor.Level.BODY
         }
 
-    /**
-     * 일반 API 호출용 OkHttpClient (AuthInterceptor + TokenAuthenticator 포함)
-     */
     @Provides
     @Singleton
-    @AuthRetrofit
     fun providesOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: AuthInterceptor,
@@ -76,35 +57,11 @@ object RetrofitModule {
                 authenticator(tokenAuthenticator)
             }.build()
 
-    /**
-     * 토큰 갱신 전용 OkHttpClient (Authenticator 제외, 데드락 방지)
-     * AuthInterceptor는 포함하지 않음 (토큰 갱신 API는 Authorization 헤더 불필요)
-     */
-    @Provides
-    @Singleton
-    @RefreshRetrofit
-    fun providesRefreshOkHttpClient(
-        loggingInterceptor: HttpLoggingInterceptor,
-    ): Call.Factory =
-        OkHttpClient
-            .Builder()
-            .apply {
-                connectTimeout(10, TimeUnit.SECONDS)
-                writeTimeout(10, TimeUnit.SECONDS)
-                readTimeout(10, TimeUnit.SECONDS)
-                if (DEBUG) addInterceptor(loggingInterceptor)
-                // AuthInterceptor와 TokenAuthenticator를 추가하지 않음
-            }.build()
-
-    /**
-     * 일반 API 호출용 Retrofit
-     */
     @OptIn(ExperimentalSerializationApi::class)
     @Provides
     @Singleton
-    @AuthRetrofit
     fun providesDoRunRetrofit(
-        @AuthRetrofit okhttpCallFactory: dagger.Lazy<Call.Factory>,
+        okhttpCallFactory: dagger.Lazy<Call.Factory>,
         json: Json,
     ): Retrofit =
         Retrofit
@@ -114,33 +71,4 @@ object RetrofitModule {
             .addConverterFactory(
                 json.asConverterFactory("application/json".toMediaType()),
             ).build()
-
-    /**
-     * 토큰 갱신 전용 Retrofit (데드락 방지)
-     */
-    @OptIn(ExperimentalSerializationApi::class)
-    @Provides
-    @Singleton
-    @RefreshRetrofit
-    fun providesRefreshRetrofit(
-        @RefreshRetrofit okhttpCallFactory: dagger.Lazy<Call.Factory>,
-        json: Json,
-    ): Retrofit =
-        Retrofit
-            .Builder()
-            .baseUrl(BuildConfig.BASE_URL)
-            .callFactory { okhttpCallFactory.get().newCall(it) }
-            .addConverterFactory(
-                json.asConverterFactory("application/json".toMediaType()),
-            ).build()
-
-    /**
-     * Qualifier 없는 기본 Call.Factory (이미지 로더 등에서 사용)
-     * @AuthRetrofit과 동일한 인스턴스 제공
-     */
-    @Provides
-    @Singleton
-    fun providesDefaultOkHttpClient(
-        @AuthRetrofit callFactory: Call.Factory,
-    ): Call.Factory = callFactory
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/di/RetrofitModule.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/di/RetrofitModule.kt
@@ -2,6 +2,8 @@ package com.dpm.sixpack.data.source.remote.di
 
 import com.dpm.sixpack.core.BuildConfig
 import com.dpm.sixpack.core.BuildConfig.DEBUG
+import com.dpm.sixpack.data.source.remote.interceptor.AuthInterceptor
+import com.dpm.sixpack.data.source.remote.interceptor.TokenAuthenticator
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,7 +17,22 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+/**
+ * 일반 API 호출용 Retrofit (AuthInterceptor + TokenAuthenticator 포함)
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthRetrofit
+
+/**
+ * 토큰 갱신 전용 Retrofit (Authenticator 제외, 데드락 방지)
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class RefreshRetrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -37,9 +54,17 @@ object RetrofitModule {
             level = HttpLoggingInterceptor.Level.BODY
         }
 
+    /**
+     * 일반 API 호출용 OkHttpClient (AuthInterceptor + TokenAuthenticator 포함)
+     */
     @Provides
     @Singleton
-    fun providesOkHttpClient(loggingInterceptor: HttpLoggingInterceptor): Call.Factory =
+    @AuthRetrofit
+    fun providesOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator,
+    ): Call.Factory =
         OkHttpClient
             .Builder()
             .apply {
@@ -47,13 +72,39 @@ object RetrofitModule {
                 writeTimeout(10, TimeUnit.SECONDS)
                 readTimeout(10, TimeUnit.SECONDS)
                 if (DEBUG) addInterceptor(loggingInterceptor)
+                addInterceptor(authInterceptor)
+                authenticator(tokenAuthenticator)
             }.build()
 
+    /**
+     * 토큰 갱신 전용 OkHttpClient (Authenticator 제외, 데드락 방지)
+     * AuthInterceptor는 포함하지 않음 (토큰 갱신 API는 Authorization 헤더 불필요)
+     */
+    @Provides
+    @Singleton
+    @RefreshRetrofit
+    fun providesRefreshOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+    ): Call.Factory =
+        OkHttpClient
+            .Builder()
+            .apply {
+                connectTimeout(10, TimeUnit.SECONDS)
+                writeTimeout(10, TimeUnit.SECONDS)
+                readTimeout(10, TimeUnit.SECONDS)
+                if (DEBUG) addInterceptor(loggingInterceptor)
+                // AuthInterceptor와 TokenAuthenticator를 추가하지 않음
+            }.build()
+
+    /**
+     * 일반 API 호출용 Retrofit
+     */
     @OptIn(ExperimentalSerializationApi::class)
     @Provides
     @Singleton
+    @AuthRetrofit
     fun providesDoRunRetrofit(
-        okhttpCallFactory: dagger.Lazy<Call.Factory>,
+        @AuthRetrofit okhttpCallFactory: dagger.Lazy<Call.Factory>,
         json: Json,
     ): Retrofit =
         Retrofit
@@ -63,4 +114,33 @@ object RetrofitModule {
             .addConverterFactory(
                 json.asConverterFactory("application/json".toMediaType()),
             ).build()
+
+    /**
+     * 토큰 갱신 전용 Retrofit (데드락 방지)
+     */
+    @OptIn(ExperimentalSerializationApi::class)
+    @Provides
+    @Singleton
+    @RefreshRetrofit
+    fun providesRefreshRetrofit(
+        @RefreshRetrofit okhttpCallFactory: dagger.Lazy<Call.Factory>,
+        json: Json,
+    ): Retrofit =
+        Retrofit
+            .Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .callFactory { okhttpCallFactory.get().newCall(it) }
+            .addConverterFactory(
+                json.asConverterFactory("application/json".toMediaType()),
+            ).build()
+
+    /**
+     * Qualifier 없는 기본 Call.Factory (이미지 로더 등에서 사용)
+     * @AuthRetrofit과 동일한 인스턴스 제공
+     */
+    @Provides
+    @Singleton
+    fun providesDefaultOkHttpClient(
+        @AuthRetrofit callFactory: Call.Factory,
+    ): Call.Factory = callFactory
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/dto/request/RefreshTokenRequestDto.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/dto/request/RefreshTokenRequestDto.kt
@@ -1,0 +1,9 @@
+package com.dpm.sixpack.data.source.remote.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenRequestDto(
+    @SerialName("refreshToken") val refreshToken: String,
+)

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/dto/response/RefreshTokenResponseDto.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/dto/response/RefreshTokenResponseDto.kt
@@ -1,0 +1,17 @@
+package com.dpm.sixpack.data.source.remote.dto.response
+
+import com.dpm.sixpack.domain.model.AuthToken
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenResponseDto(
+    @SerialName("accessToken") val accessToken: String,
+    @SerialName("refreshToken") val refreshToken: String,
+) {
+    fun toAuthToken() =
+        AuthToken(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+        )
+}

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/interceptor/AuthInterceptor.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/interceptor/AuthInterceptor.kt
@@ -7,6 +7,9 @@ import okhttp3.Response
 import timber.log.Timber
 import javax.inject.Inject
 
+/**
+ * 모든 API 요청에 인증 헤더를 자동으로 추가하는 Interceptor
+ */
 class AuthInterceptor
     @Inject
     constructor(
@@ -14,23 +17,28 @@ class AuthInterceptor
     ) : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             val originalRequest = chain.request()
-
-            val userId =
-                runBlocking {
-                    try {
-                        userPreferenceRepository.getUserId().toString()
-                    } catch (e: Exception) {
-                        Timber.e("AuthInterceptor: Failed to get UserId from DataStore. message: ${e.message}")
-                        null
-                    }
-                }
-
             val requestBuilder = originalRequest.newBuilder()
 
-            if (userId != null) {
-                requestBuilder.addHeader(X_USER_ID, userId)
-            } else {
-                Timber.e("AuthInterceptor: UserId is null, proceeding without X-User-Id header.")
+            runBlocking {
+                try {
+                    // X-User-Id 헤더 추가
+                    val userId = userPreferenceRepository.getUserId()
+                    requestBuilder.addHeader(X_USER_ID, userId.toString())
+                } catch (e: Exception) {
+                    Timber.e("AuthInterceptor: Failed to get UserId: ${e.message}")
+                }
+
+                try {
+                    // Authorization Bearer 헤더 추가
+                    val accessToken = userPreferenceRepository.getAccessToken()
+                    if (!accessToken.isNullOrBlank()) {
+                        requestBuilder.addHeader(AUTHORIZATION, "$BEARER $accessToken")
+                    } else {
+                        Timber.d("AuthInterceptor: AccessToken is null, proceeding without Authorization header")
+                    }
+                } catch (e: Exception) {
+                    Timber.e("AuthInterceptor: Failed to get AccessToken: ${e.message}")
+                }
             }
 
             val newRequest = requestBuilder.build()
@@ -39,5 +47,7 @@ class AuthInterceptor
 
         companion object {
             private const val X_USER_ID = "X-User-Id"
+            private const val AUTHORIZATION = "Authorization"
+            private const val BEARER = "Bearer"
         }
     }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/interceptor/TokenAuthenticator.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/interceptor/TokenAuthenticator.kt
@@ -1,5 +1,6 @@
 package com.dpm.sixpack.data.source.remote.interceptor
 
+import com.dpm.sixpack.data.source.remote.util.constant.ApiConstants.TOKEN_REFRESH_PATH
 import com.dpm.sixpack.domain.model.AuthEvent
 import com.dpm.sixpack.domain.repository.AuthRepository
 import com.dpm.sixpack.domain.repository.UserPreferenceRepository
@@ -27,111 +28,118 @@ import javax.inject.Inject
  * 7. 실패 시: 토큰 삭제 및 AuthEvent 발행, 로그인 화면 리다이렉트
  */
 class TokenAuthenticator
-    @Inject
-    constructor(
-        private val userPreferenceRepository: UserPreferenceRepository,
-        private val authRepository: AuthRepository,
-    ) : Authenticator {
-        // 동시 토큰 갱신 요청 방지를 위한 lock
-        private val lock = Any()
+@Inject
+constructor(
+    private val userPreferenceRepository: UserPreferenceRepository,
+    private val authRepository: AuthRepository,
+) : Authenticator {
+    // 동시 토큰 갱신 요청 방지를 위한 lock
+    private val lock = Any()
 
-        override fun authenticate(
-            route: Route?,
-            response: Response,
-        ): Request? {
-            // 이미 재시도한 요청은 포기 (무한 루프 방지)
-            if (response.request.header(RETRY_HEADER) != null) {
-                Timber.e("TokenAuthenticator: Already retried, giving up.")
-                return null
-            }
+    override fun authenticate(
+        route: Route?,
+        response: Response,
+    ): Request? {
+        // 토큰 갱신 API 자체가 401이면 재시도하지 않음
+        if (response.request.url.encodedPath.contains(TOKEN_REFRESH_PATH)) {
+            Timber.e("TokenAuthenticator: Token refresh API failed with 401, giving up.")
+            return null
+        }
 
-            // 401이 아니면 처리하지 않음
-            if (response.code != 401) {
-                Timber.d("TokenAuthenticator: Response code is not 401, skipping token refresh.")
-                return null
-            }
+        // 이미 재시도한 요청은 포기 (무한 루프 방지)
+        if (response.request.header(RETRY_HEADER) != null) {
+            Timber.e("TokenAuthenticator: Already retried, giving up.")
+            return null
+        }
 
-            // synchronized 블록으로 동시 토큰 갱신 방지
-            synchronized(lock) {
-                return runBlocking {
-                    try {
-                        // 현재 저장된 AccessToken 확인
-                        val currentAccessToken = userPreferenceRepository.getAccessToken()
+        // 401이 아니면 처리하지 않음
+        if (response.code != 401) {
+            Timber.d("TokenAuthenticator: Response code is not 401, skipping token refresh.")
+            return null
+        }
 
-                        // 이 요청이 사용한 토큰 추출
-                        val requestToken =
+        // synchronized 블록으로 동시 토큰 갱신 방지
+        synchronized(lock) {
+            return runBlocking {
+                try {
+                    // 현재 저장된 AccessToken 확인
+                    val currentAccessToken = userPreferenceRepository.getAccessToken()
+
+                    // 이 요청이 사용한 토큰 추출
+                    val requestToken =
+                        response.request
+                            .header("Authorization")
+                            ?.removePrefix("Bearer ")
+                            ?.trim()
+
+                    // 토큰이 이미 갱신된 경우 (다른 스레드가 갱신 완료)
+                    if (requestToken != currentAccessToken && !currentAccessToken.isNullOrBlank()) {
+                        Timber.d("TokenAuthenticator: Token already refreshed by another request, using new token")
+                        // 새 토큰으로 재시도
+                        return@runBlocking response.request
+                            .newBuilder()
+                            .header("Authorization", "Bearer $currentAccessToken")
+                            .header(RETRY_HEADER, "true")
+                            .build()
+                    }
+
+                    // 첫 번째 요청이므로 실제로 토큰 갱신 수행
+                    val currentRefreshToken = userPreferenceRepository.getRefreshToken()
+
+                    if (currentRefreshToken.isNullOrBlank()) {
+                        Timber.e("TokenAuthenticator: RefreshToken is null or blank, cannot refresh")
+                        // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
+                        userPreferenceRepository.clearTokens()
+                        userPreferenceRepository.emitAuthEvent(AuthEvent.TokenExpired)
+                        return@runBlocking null
+                    }
+
+                    // AuthRepository로 토큰 갱신 API 호출
+                    Timber.d("TokenAuthenticator: Attempting token refresh")
+                    val result = authRepository.refreshToken(currentRefreshToken)
+
+                    // when 표현식으로 Result 처리 (onSuccess/onError는 제대로 return되지 않음)
+                    when (result) {
+                        is DoRunResult.Success -> {
+                            val authToken = result.data
+                            Timber.d("TokenAuthenticator: Token refresh successful")
+                            // 토큰 저장
+                            userPreferenceRepository.updateAccessToken(authToken.accessToken)
+                            userPreferenceRepository.updateRefreshToken(authToken.refreshToken)
+                            // 새 AccessToken으로 원래 요청 재시도
                             response.request
-                                .header("Authorization")
-                                ?.removePrefix("Bearer ")
-                                ?.trim()
-
-                        // 토큰이 이미 갱신된 경우 (다른 스레드가 갱신 완료)
-                        if (requestToken != currentAccessToken && !currentAccessToken.isNullOrBlank()) {
-                            Timber.d("TokenAuthenticator: Token already refreshed by another request, using new token")
-                            // 새 토큰으로 재시도
-                            return@runBlocking response.request
                                 .newBuilder()
-                                .header("Authorization", "Bearer $currentAccessToken")
+                                .header("Authorization", "Bearer ${authToken.accessToken}")
                                 .header(RETRY_HEADER, "true")
                                 .build()
                         }
 
-                        // 첫 번째 요청이므로 실제로 토큰 갱신 수행
-                        val currentRefreshToken = userPreferenceRepository.getRefreshToken()
-
-                        if (currentRefreshToken.isNullOrBlank()) {
-                            Timber.e("TokenAuthenticator: RefreshToken is null or blank, cannot refresh")
+                        is DoRunResult.Failure -> {
+                            val exception = result.exception
+                            Timber.e("TokenAuthenticator: Token refresh failed: ${exception.message}")
                             // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
+                            // 모든 대기 중인 요청도 null을 반환받아 취소됨
                             userPreferenceRepository.clearTokens()
-                            userPreferenceRepository.emitAuthEvent(AuthEvent.TokenExpired)
-                            return@runBlocking null
+                            userPreferenceRepository.emitAuthEvent(
+                                AuthEvent.TokenRefreshFailed(exception.message ?: "Unknown error"),
+                            )
+                            null
                         }
-
-                        // AuthRepository로 토큰 갱신 API 호출
-                        Timber.d("TokenAuthenticator: Attempting token refresh")
-                        val result = authRepository.refreshToken(currentRefreshToken)
-
-                        // when 표현식으로 Result 처리 (onSuccess/onError는 제대로 return되지 않음)
-                        when (result) {
-                            is DoRunResult.Success -> {
-                                val authToken = result.data
-                                Timber.d("TokenAuthenticator: Token refresh successful")
-                                // 토큰 저장
-                                userPreferenceRepository.updateAccessToken(authToken.accessToken)
-                                userPreferenceRepository.updateRefreshToken(authToken.refreshToken)
-                                // 새 AccessToken으로 원래 요청 재시도
-                                response.request
-                                    .newBuilder()
-                                    .header("Authorization", "Bearer ${authToken.accessToken}")
-                                    .header(RETRY_HEADER, "true")
-                                    .build()
-                            }
-                            is DoRunResult.Failure -> {
-                                val exception = result.exception
-                                Timber.e("TokenAuthenticator: Token refresh failed: ${exception.message}")
-                                // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
-                                // 모든 대기 중인 요청도 null을 반환받아 취소됨
-                                userPreferenceRepository.clearTokens()
-                                userPreferenceRepository.emitAuthEvent(
-                                    AuthEvent.TokenRefreshFailed(exception.message ?: "Unknown error"),
-                                )
-                                null
-                            }
-                        }
-                    } catch (e: Exception) {
-                        Timber.e("TokenAuthenticator: Exception during token refresh: ${e.message}")
-                        // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
-                        userPreferenceRepository.clearTokens()
-                        userPreferenceRepository.emitAuthEvent(
-                            AuthEvent.TokenRefreshFailed(e.message ?: "Unknown exception"),
-                        )
-                        null
                     }
+                } catch (e: Exception) {
+                    Timber.e("TokenAuthenticator: Exception during token refresh: ${e.message}")
+                    // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
+                    userPreferenceRepository.clearTokens()
+                    userPreferenceRepository.emitAuthEvent(
+                        AuthEvent.TokenRefreshFailed(e.message ?: "Unknown exception"),
+                    )
+                    null
                 }
             }
         }
-
-        companion object {
-            private const val RETRY_HEADER = "X-Token-Retry"
-        }
     }
+
+    companion object {
+        private const val RETRY_HEADER = "X-Token-Retry"
+    }
+}

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/interceptor/TokenAuthenticator.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/interceptor/TokenAuthenticator.kt
@@ -1,0 +1,137 @@
+package com.dpm.sixpack.data.source.remote.interceptor
+
+import com.dpm.sixpack.domain.model.AuthEvent
+import com.dpm.sixpack.domain.repository.AuthRepository
+import com.dpm.sixpack.domain.repository.UserPreferenceRepository
+import com.dpm.sixpack.domain.util.DoRunResult
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * 401 Unauthorized 응답 시 자동으로 토큰을 갱신하는 Authenticator
+ *
+ * 동작 흐름:
+ * 1. API 호출이 401 응답 반환
+ * 2. OkHttp가 이 Authenticator 호출
+ * 3. synchronized 블록으로 동시 요청 제어
+ *    - 첫 번째 요청: 실제 토큰 갱신 API 호출
+ *    - 나머지 요청: 대기 후 갱신된 토큰으로 재시도 또는 취소
+ * 4. UserPreferenceRepository에서 RefreshToken 가져오기
+ * 5. AuthRepository로 토큰 갱신 API 호출
+ * 6. 성공 시: 토큰 저장 후 새 AccessToken으로 요청 재시도
+ * 7. 실패 시: 토큰 삭제 및 AuthEvent 발행, 로그인 화면 리다이렉트
+ */
+class TokenAuthenticator
+    @Inject
+    constructor(
+        private val userPreferenceRepository: UserPreferenceRepository,
+        private val authRepository: AuthRepository,
+    ) : Authenticator {
+        // 동시 토큰 갱신 요청 방지를 위한 lock
+        private val lock = Any()
+
+        override fun authenticate(
+            route: Route?,
+            response: Response,
+        ): Request? {
+            // 이미 재시도한 요청은 포기 (무한 루프 방지)
+            if (response.request.header(RETRY_HEADER) != null) {
+                Timber.e("TokenAuthenticator: Already retried, giving up.")
+                return null
+            }
+
+            // 401이 아니면 처리하지 않음
+            if (response.code != 401) {
+                Timber.d("TokenAuthenticator: Response code is not 401, skipping token refresh.")
+                return null
+            }
+
+            // synchronized 블록으로 동시 토큰 갱신 방지
+            synchronized(lock) {
+                return runBlocking {
+                    try {
+                        // 현재 저장된 AccessToken 확인
+                        val currentAccessToken = userPreferenceRepository.getAccessToken()
+
+                        // 이 요청이 사용한 토큰 추출
+                        val requestToken =
+                            response.request
+                                .header("Authorization")
+                                ?.removePrefix("Bearer ")
+                                ?.trim()
+
+                        // 토큰이 이미 갱신된 경우 (다른 스레드가 갱신 완료)
+                        if (requestToken != currentAccessToken && !currentAccessToken.isNullOrBlank()) {
+                            Timber.d("TokenAuthenticator: Token already refreshed by another request, using new token")
+                            // 새 토큰으로 재시도
+                            return@runBlocking response.request
+                                .newBuilder()
+                                .header("Authorization", "Bearer $currentAccessToken")
+                                .header(RETRY_HEADER, "true")
+                                .build()
+                        }
+
+                        // 첫 번째 요청이므로 실제로 토큰 갱신 수행
+                        val currentRefreshToken = userPreferenceRepository.getRefreshToken()
+
+                        if (currentRefreshToken.isNullOrBlank()) {
+                            Timber.e("TokenAuthenticator: RefreshToken is null or blank, cannot refresh")
+                            // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
+                            userPreferenceRepository.clearTokens()
+                            userPreferenceRepository.emitAuthEvent(AuthEvent.TokenExpired)
+                            return@runBlocking null
+                        }
+
+                        // AuthRepository로 토큰 갱신 API 호출
+                        Timber.d("TokenAuthenticator: Attempting token refresh")
+                        val result = authRepository.refreshToken(currentRefreshToken)
+
+                        // when 표현식으로 Result 처리 (onSuccess/onError는 제대로 return되지 않음)
+                        when (result) {
+                            is DoRunResult.Success -> {
+                                val authToken = result.data
+                                Timber.d("TokenAuthenticator: Token refresh successful")
+                                // 토큰 저장
+                                userPreferenceRepository.updateAccessToken(authToken.accessToken)
+                                userPreferenceRepository.updateRefreshToken(authToken.refreshToken)
+                                // 새 AccessToken으로 원래 요청 재시도
+                                response.request
+                                    .newBuilder()
+                                    .header("Authorization", "Bearer ${authToken.accessToken}")
+                                    .header(RETRY_HEADER, "true")
+                                    .build()
+                            }
+                            is DoRunResult.Failure -> {
+                                val exception = result.exception
+                                Timber.e("TokenAuthenticator: Token refresh failed: ${exception.message}")
+                                // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
+                                // 모든 대기 중인 요청도 null을 반환받아 취소됨
+                                userPreferenceRepository.clearTokens()
+                                userPreferenceRepository.emitAuthEvent(
+                                    AuthEvent.TokenRefreshFailed(exception.message ?: "Unknown error"),
+                                )
+                                null
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Timber.e("TokenAuthenticator: Exception during token refresh: ${e.message}")
+                        // 인증 세션 종료 (토큰 삭제 + AuthEvent 발행)
+                        userPreferenceRepository.clearTokens()
+                        userPreferenceRepository.emitAuthEvent(
+                            AuthEvent.TokenRefreshFailed(e.message ?: "Unknown exception"),
+                        )
+                        null
+                    }
+                }
+            }
+        }
+
+        companion object {
+            private const val RETRY_HEADER = "X-Token-Retry"
+        }
+    }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/service/AuthService.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/service/AuthService.kt
@@ -7,6 +7,7 @@ import com.dpm.sixpack.data.source.remote.dto.response.RefreshTokenResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.SignUpResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.VerifySmsResponseDto
 import com.dpm.sixpack.data.source.remote.util.base.BaseResponse
+import com.dpm.sixpack.data.source.remote.util.constant.ApiConstants.TOKEN_REFRESH_PATH
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Response
@@ -33,7 +34,7 @@ interface AuthService {
         @Part profileImage: MultipartBody.Part?,
     ): BaseResponse<SignUpResponseDto>
 
-    @POST("/api/auth/refresh")
+    @POST(TOKEN_REFRESH_PATH)
     suspend fun refreshToken(
         @Body request: RefreshTokenRequestDto,
     ): BaseResponse<RefreshTokenResponseDto>

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/service/AuthService.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/service/AuthService.kt
@@ -1,7 +1,9 @@
 package com.dpm.sixpack.data.source.remote.service
 
+import com.dpm.sixpack.data.source.remote.dto.request.RefreshTokenRequestDto
 import com.dpm.sixpack.data.source.remote.dto.request.SendSmsRequestDto
 import com.dpm.sixpack.data.source.remote.dto.request.VerifySmsRequestDto
+import com.dpm.sixpack.data.source.remote.dto.response.RefreshTokenResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.SignUpResponseDto
 import com.dpm.sixpack.data.source.remote.dto.response.VerifySmsResponseDto
 import com.dpm.sixpack.data.source.remote.util.base.BaseResponse
@@ -30,4 +32,9 @@ interface AuthService {
         @Part("data") data: RequestBody,
         @Part profileImage: MultipartBody.Part?,
     ): BaseResponse<SignUpResponseDto>
+
+    @POST("/api/auth/refresh")
+    suspend fun refreshToken(
+        @Body request: RefreshTokenRequestDto,
+    ): BaseResponse<RefreshTokenResponseDto>
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/service/di/ServiceModule.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/service/di/ServiceModule.kt
@@ -1,7 +1,5 @@
 package com.dpm.sixpack.data.source.remote.service.di
 
-import com.dpm.sixpack.data.source.remote.di.AuthRetrofit
-import com.dpm.sixpack.data.source.remote.di.RefreshRetrofit
 import com.dpm.sixpack.data.source.remote.service.AuthService
 import com.dpm.sixpack.data.source.remote.service.FeedService
 import com.dpm.sixpack.data.source.remote.service.RunningGoalService
@@ -17,43 +15,21 @@ import kotlin.jvm.java
 @Module
 @InstallIn(SingletonComponent::class)
 object ServiceModule {
-    /**
-     * 일반 API 호출용 AuthService (AuthInterceptor + TokenAuthenticator 포함)
-     */
     @Provides
     @Singleton
-    @AuthRetrofit
-    fun provideAuthService(
-        @AuthRetrofit retrofit: Retrofit,
-    ): AuthService = retrofit.create(AuthService::class.java)
-
-    /**
-     * 토큰 갱신 전용 AuthService (Authenticator 제외, 데드락 방지)
-     */
-    @Provides
-    @Singleton
-    @RefreshRetrofit
-    fun provideRefreshAuthService(
-        @RefreshRetrofit retrofit: Retrofit,
-    ): AuthService = retrofit.create(AuthService::class.java)
+    fun provideAuthService(retrofit: Retrofit): AuthService = retrofit.create(AuthService::class.java)
 
     @Provides
     @Singleton
-    fun provideRunningGoalService(
-        @AuthRetrofit retrofit: Retrofit,
-    ): RunningGoalService =
+    fun provideRunningGoalService(retrofit: Retrofit): RunningGoalService =
         retrofit.create(RunningGoalService::class.java)
 
     @Provides
     @Singleton
-    fun provideRunningSessionService(
-        @AuthRetrofit retrofit: Retrofit,
-    ): RunningSessionService =
+    fun provideRunningSessionService(retrofit: Retrofit): RunningSessionService =
         retrofit.create(RunningSessionService::class.java)
 
     @Provides
     @Singleton
-    fun provideFeedService(
-        @AuthRetrofit retrofit: Retrofit,
-    ): FeedService = retrofit.create(FeedService::class.java)
+    fun provideFeedService(retrofit: Retrofit): FeedService = retrofit.create(FeedService::class.java)
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/service/di/ServiceModule.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/service/di/ServiceModule.kt
@@ -1,5 +1,7 @@
 package com.dpm.sixpack.data.source.remote.service.di
 
+import com.dpm.sixpack.data.source.remote.di.AuthRetrofit
+import com.dpm.sixpack.data.source.remote.di.RefreshRetrofit
 import com.dpm.sixpack.data.source.remote.service.AuthService
 import com.dpm.sixpack.data.source.remote.service.FeedService
 import com.dpm.sixpack.data.source.remote.service.RunningGoalService
@@ -15,21 +17,43 @@ import kotlin.jvm.java
 @Module
 @InstallIn(SingletonComponent::class)
 object ServiceModule {
+    /**
+     * 일반 API 호출용 AuthService (AuthInterceptor + TokenAuthenticator 포함)
+     */
     @Provides
     @Singleton
-    fun provideAuthService(retrofit: Retrofit): AuthService = retrofit.create(AuthService::class.java)
+    @AuthRetrofit
+    fun provideAuthService(
+        @AuthRetrofit retrofit: Retrofit,
+    ): AuthService = retrofit.create(AuthService::class.java)
+
+    /**
+     * 토큰 갱신 전용 AuthService (Authenticator 제외, 데드락 방지)
+     */
+    @Provides
+    @Singleton
+    @RefreshRetrofit
+    fun provideRefreshAuthService(
+        @RefreshRetrofit retrofit: Retrofit,
+    ): AuthService = retrofit.create(AuthService::class.java)
 
     @Provides
     @Singleton
-    fun provideRunningGoalService(retrofit: Retrofit): RunningGoalService =
+    fun provideRunningGoalService(
+        @AuthRetrofit retrofit: Retrofit,
+    ): RunningGoalService =
         retrofit.create(RunningGoalService::class.java)
 
     @Provides
     @Singleton
-    fun provideRunningSessionService(retrofit: Retrofit): RunningSessionService =
+    fun provideRunningSessionService(
+        @AuthRetrofit retrofit: Retrofit,
+    ): RunningSessionService =
         retrofit.create(RunningSessionService::class.java)
 
     @Provides
     @Singleton
-    fun provideFeedService(retrofit: Retrofit): FeedService = retrofit.create(FeedService::class.java)
+    fun provideFeedService(
+        @AuthRetrofit retrofit: Retrofit,
+    ): FeedService = retrofit.create(FeedService::class.java)
 }

--- a/data/src/main/java/com/dpm/sixpack/data/source/remote/util/constant/ApiConstants.kt
+++ b/data/src/main/java/com/dpm/sixpack/data/source/remote/util/constant/ApiConstants.kt
@@ -10,4 +10,6 @@ object ApiConstants {
     const val PLANS = "plans"
     const val SELFIE = "selfie"
     const val FEEDS = "feeds"
+
+    const val TOKEN_REFRESH_PATH = "/api/auth/refresh"
 }

--- a/domain/src/main/java/com/dpm/sixpack/domain/model/AuthEvent.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/model/AuthEvent.kt
@@ -1,0 +1,14 @@
+package com.dpm.sixpack.domain.model
+
+sealed class AuthEvent {
+
+    data object LoggedOut : AuthEvent()
+
+    data object TokenExpired : AuthEvent()
+
+    data class TokenRefreshFailed(
+        val reason: String,
+    ) : AuthEvent()
+
+    data object SessionInvalidated : AuthEvent()
+}

--- a/domain/src/main/java/com/dpm/sixpack/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.dpm.sixpack.domain.repository
 
+import com.dpm.sixpack.domain.model.AuthToken
 import com.dpm.sixpack.domain.model.SignUpResult
 import com.dpm.sixpack.domain.model.SmsVerificationResult
 import com.dpm.sixpack.domain.util.DoRunResult
@@ -18,4 +19,6 @@ interface AuthRepository {
         phoneNumber: String,
         profileImage: File?,
     ): DoRunResult<SignUpResult>
+
+    suspend fun refreshToken(refreshToken: String): DoRunResult<AuthToken>
 }

--- a/domain/src/main/java/com/dpm/sixpack/domain/repository/UserPreferenceRepository.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/repository/UserPreferenceRepository.kt
@@ -1,6 +1,14 @@
 package com.dpm.sixpack.domain.repository
 
+import com.dpm.sixpack.domain.model.AuthEvent
+import kotlinx.coroutines.flow.SharedFlow
+
 interface UserPreferenceRepository {
+    /**
+     * 토큰 갱신 실패시 로그아웃 시키고  로그인 화면으로 리다이렉트 시키려고 만듦
+     */
+    val authEvents: SharedFlow<AuthEvent>
+
     suspend fun getUserId(): Long
 
     suspend fun getSessionId(): Long?
@@ -20,4 +28,9 @@ interface UserPreferenceRepository {
     suspend fun updateRefreshToken(token: String)
 
     suspend fun clearTokens()
+
+    /**
+     * 토큰 갱신 실패시 로그아웃 시키고 로그인 화면으로 리다이렉트 시키려고 만듦
+     */
+    suspend fun emitAuthEvent(event: AuthEvent)
 }

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/SignUpUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/SignUpUseCase.kt
@@ -7,24 +7,26 @@ import com.dpm.sixpack.domain.util.DoRunResult
 import java.io.File
 import javax.inject.Inject
 
-class SignUpUseCase @Inject constructor(
-    private val authRepository: AuthRepository,
-    private val userPreferenceRepository: UserPreferenceRepository,
-) {
-    suspend operator fun invoke(
-        nickname: String,
-        phoneNumber: String,
-        profileImage: File?,
-    ): DoRunResult<SignUpResult> {
-        val result = authRepository.signUp(nickname, phoneNumber, profileImage)
+class SignUpUseCase
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val userPreferenceRepository: UserPreferenceRepository,
+    ) {
+        suspend operator fun invoke(
+            nickname: String,
+            phoneNumber: String,
+            profileImage: File?,
+        ): DoRunResult<SignUpResult> {
+            val result = authRepository.signUp(nickname, phoneNumber, profileImage)
 
-        // 회원가입 성공 시 userId, token 저장
-        result.onSuccess { signUpResult ->
-            userPreferenceRepository.updateUserId(signUpResult.user.id)
-            userPreferenceRepository.updateAccessToken(signUpResult.token.accessToken)
-            userPreferenceRepository.updateRefreshToken(signUpResult.token.refreshToken)
+            // 회원가입 성공 시 userId, token 저장
+            result.onSuccess { signUpResult ->
+                userPreferenceRepository.updateUserId(signUpResult.user.id)
+                userPreferenceRepository.updateAccessToken(signUpResult.token.accessToken)
+                userPreferenceRepository.updateRefreshToken(signUpResult.token.refreshToken)
+            }
+
+            return result
         }
-
-        return result
     }
-}

--- a/domain/src/main/java/com/dpm/sixpack/domain/usecase/VerifySmsCodeUseCase.kt
+++ b/domain/src/main/java/com/dpm/sixpack/domain/usecase/VerifySmsCodeUseCase.kt
@@ -6,27 +6,29 @@ import com.dpm.sixpack.domain.repository.UserPreferenceRepository
 import com.dpm.sixpack.domain.util.DoRunResult
 import javax.inject.Inject
 
-class VerifySmsCodeUseCase @Inject constructor(
-    private val authRepository: AuthRepository,
-    private val userPreferenceRepository: UserPreferenceRepository,
-) {
-    suspend operator fun invoke(
-        phoneNumber: String,
-        verificationCode: String,
-    ): DoRunResult<SmsVerificationResult> {
-        val result = authRepository.verifySmsCode(phoneNumber, verificationCode)
+class VerifySmsCodeUseCase
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val userPreferenceRepository: UserPreferenceRepository,
+    ) {
+        suspend operator fun invoke(
+            phoneNumber: String,
+            verificationCode: String,
+        ): DoRunResult<SmsVerificationResult> {
+            val result = authRepository.verifySmsCode(phoneNumber, verificationCode)
 
-        // 인증 성공 시 userId와 token 저장
-        result.onSuccess { verificationResult ->
-            verificationResult.user?.let { user ->
-                userPreferenceRepository.updateUserId(user.id)
+            // 인증 성공 시 userId와 token 저장
+            result.onSuccess { verificationResult ->
+                verificationResult.user?.let { user ->
+                    userPreferenceRepository.updateUserId(user.id)
+                }
+                verificationResult.token?.let { token ->
+                    userPreferenceRepository.updateAccessToken(token.accessToken)
+                    userPreferenceRepository.updateRefreshToken(token.refreshToken)
+                }
             }
-            verificationResult.token?.let { token ->
-                userPreferenceRepository.updateAccessToken(token.accessToken)
-                userPreferenceRepository.updateRefreshToken(token.refreshToken)
-            }
+
+            return result
         }
-
-        return result
     }
-}


### PR DESCRIPTION
## Closed Issue
- closed issue: #73 

## 변경 내용과 목적  
동작 흐름:
1. API 호출이 401 응답 반환
2. OkHttp가 이 Authenticator 호출
3. synchronized 블록으로 동시 요청 제어
   - 첫 번째 요청: 실제 토큰 갱신 API 호출
   - 나머지 요청: 대기 후 갱신된 토큰으로 재시도 또는 취소
4. UserPreferenceRepository에서 RefreshToken 가져오기
5. AuthRepository로 토큰 갱신 API 호출
6. 성공 시: 토큰 저장 후 새 AccessToken으로 요청 재시도
7. 실패 시: 토큰 삭제 및 AuthEvent 발행, 로그인 화면 리다이렉트  

## 🙏 Reviewer 가 신경써서 볼만한 포인트  
- 위 내용 큰 구조로 봐주시고 같이 개선해보면 좋겠어요. 
  - (MVP 런칭 이후면 더 좋을 것 같아요)
- TokenAuthenticator 여기에 주요 내용이 있어요.
  - API를 동시에 요청했을 때 401이 떨어진 케이스에 리프레시 API를 한번만 요청하게 만드느라 시간이 좀 걸렸어요. 더 나은 방법이 있다면 말씀 부탁드립니다.

💪  개발 완료까지 3일.. 화이팅이요 💪 