### PR TITLE
#102 백그라운드 위치 권한 요청 플로우 추가

### DIFF
--- a/app/src/main/java/com/dpm/sixpack/main/MainScreen.kt
+++ b/app/src/main/java/com/dpm/sixpack/main/MainScreen.kt
@@ -14,16 +14,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dpm.sixpack.SixPackAppState
-import com.dpm.sixpack.core.permission.SixPackPermissions.Companion.AllPermissions
 import com.dpm.sixpack.main.navigation.MainNavHost
 import com.dpm.sixpack.presentation.common.components.DoRunSnackBar
 import com.dpm.sixpack.presentation.common.components.FullScreenLoadingIndicator
-import com.dpm.sixpack.presentation.common.util.PermissionHandler
 import com.dpm.sixpack.presentation.navigation.MainBottomBar
 import com.dpm.sixpack.presentation.navigation.MainNavTab
 import com.dpm.sixpack.presentation.theme.SixpackTheme
@@ -36,23 +32,15 @@ internal fun MainScreen(
     showFullScreenLoading: Boolean = false,
     setFullScreenLoading: (Boolean) -> Unit = {},
 ) {
-    val snackbarHostState = remember { SnackbarHostState() }
+    val snackBarHostState = remember { SnackbarHostState() }
     val isOffline by appState.isOffline.collectAsStateWithLifecycle()
 
     // FIXME: Replace with actual string resource
     val notConnectedMessage = "stringResource(R.string.not_connected)"
 
-    PermissionHandler(
-        context = LocalContext.current,
-        lifecycleOwner = LocalLifecycleOwner.current,
-        permissionsToRequest = AllPermissions,
-        onPermissionResult = { isGranted ->
-        },
-    )
-
     LaunchedEffect(isOffline) {
         if (isOffline) {
-            snackbarHostState.showSnackbar(
+            snackBarHostState.showSnackbar(
                 message = notConnectedMessage,
                 duration = Indefinite,
             )
@@ -62,7 +50,7 @@ internal fun MainScreen(
     MainScreenContent(
         modifier = modifier,
         appState = appState,
-        snackbarHostState = snackbarHostState,
+        snackbarHostState = snackBarHostState,
         showFullScreenLoading = showFullScreenLoading,
         setFullScreenLoading = setFullScreenLoading,
     )

--- a/background/src/main/java/com/dpm/sixpack/firebaseMessageService/FcmService.kt
+++ b/background/src/main/java/com/dpm/sixpack/firebaseMessageService/FcmService.kt
@@ -33,9 +33,11 @@ class FcmService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         super.onMessageReceived(remoteMessage)
 
+        Timber.d("fcm data received: ${remoteMessage.data}")
+
         // 데이터 페이로드 처리 (서버에서 보낸 key-value 데이터)
         if (remoteMessage.data.isNotEmpty()) {
-            // 데이터 처리 로직 (예: UI 갱신, 백그라운드 작업)
+            Timber.d("fcm data received not null: ${remoteMessage.data}")
         }
 
         // ⬇️ 포그라운드 상태에서 '알림' 메시지를 받았을 때

--- a/core/src/main/java/com/dpm/sixpack/core/permission/PermissionUtil.kt
+++ b/core/src/main/java/com/dpm/sixpack/core/permission/PermissionUtil.kt
@@ -52,7 +52,7 @@ object PermissionUtil {
             }
         }
 
-    fun requestPermission(
+    fun requestPermissions(
         context: Context,
         permissionsLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>,
         permissions: List<SixPackPermissions>,
@@ -61,6 +61,15 @@ object PermissionUtil {
             savePermissionRequested(context, it)
         }
         permissionsLauncher.launch(permissions.toStringArray())
+    }
+
+    fun requestPermission(
+        context: Context,
+        permissionsLauncher: ManagedActivityResultLauncher<String, Boolean>,
+        permissions: SixPackPermissions,
+    ) {
+        savePermissionRequested(context, permissions)
+        permissionsLauncher.launch(permissions.permission)
     }
 
     fun clearAllPermissionData(context: Context) {

--- a/core/src/main/java/com/dpm/sixpack/core/permission/SixPackPermissions.kt
+++ b/core/src/main/java/com/dpm/sixpack/core/permission/SixPackPermissions.kt
@@ -80,13 +80,6 @@ sealed class SixPackPermissions(
                 FineLocationPermission,
                 CourseLocationPermission,
             )
-//                if (Build.VERSION.SDK_INT >=
-//                    Build.VERSION_CODES.Q
-//                ) {
-//                    listOf(BackgroundLocationPermission)
-//                } else {
-//                    emptyList()
-//                }
         }
 
         val ForegroundServicePermissions by lazy {
@@ -102,16 +95,14 @@ sealed class SixPackPermissions(
 
         val SensorPermissions by lazy {
             mutableListOf<SixPackPermissions>().apply {
-                addAll(ForegroundServicePermissions)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     add(ActivityRecognitionPermission)
                 }
             }
         }
 
-        val RequiredPermissions by lazy {
+        val NotificationPermissions by lazy {
             mutableListOf<SixPackPermissions>().apply {
-                addAll(SensorPermissions)
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     add(NotificationPermission)
                 }
@@ -127,9 +118,5 @@ sealed class SixPackPermissions(
                 }
             }
         }
-
-        val OptionalPermissions = LocationPermissions
-
-        val AllPermissions = RequiredPermissions + OptionalPermissions
     }
 }

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/common/util/BackgroundPermissionHandler.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/common/util/BackgroundPermissionHandler.kt
@@ -1,0 +1,108 @@
+package com.dpm.sixpack.presentation.common.util
+
+import android.content.Context
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.dpm.sixpack.core.permission.PermissionUtil
+import com.dpm.sixpack.core.permission.SixPackPermissions
+
+/**
+ * 백그라운드 위치 권한("항상 허용")을 전담으로 처리하는 핸들러.
+ * 안드로이드 11+의 2단계 권한 요청 로직을 자동으로 수행합니다.
+ *
+ * @param onPermissionResult "항상 허용"이 최종 승인되었는지 여부를 반환 (true/false)
+ * @param onShowRationale "항상 허용"이 왜 필요한지 설명하는 다이얼로그를 띄워야 할 때 호출됩니다.
+ * 이 콜백은 "설정으로 이동"하는 람다(launcher)를 파라미터로 전달합니다.
+ * UI는 이 람다를 "확인" 버튼 등에 연결해야 합니다.
+ */
+@Composable
+fun BackgroundPermissionHandler(
+    context: Context,
+    lifecycleOwner: LifecycleOwner,
+    foregroundPermissions: List<SixPackPermissions>,
+    backgroundPermission: SixPackPermissions? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) SixPackPermissions.BackgroundLocationPermission else null,
+    onPermissionResult: (Boolean, Boolean) -> Unit,
+    onShowRationale: (launchSettings: () -> Unit) -> Unit,
+) {
+    // --- 필요한 권한 문자열 정의 ---
+    fun hasForegroundPermission(): Boolean = PermissionUtil.hasPermissions(context, foregroundPermissions)
+
+    fun hasBackgroundPermission(): Boolean =
+        if (backgroundPermission != null) PermissionUtil.hasPermissions(context, listOf(backgroundPermission)) else true
+
+    val backgroundLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) {
+            // 설정 화면에서 돌아왔을 때, "항상 허용"이 되었는지 최종 체크
+            onPermissionResult(hasForegroundPermission(), hasBackgroundPermission())
+        }
+
+    // --- 전경 권한 런처 (앱 내 팝업) ---
+    val foregroundLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestMultiplePermissions(),
+        ) { permissions ->
+            val isForegroundGranted = permissions.values.any { it }
+
+            if (isForegroundGranted) {
+                // 1단계(전경) 성공 -> 2단계(백그라운드)를 위해 Rationale(이유) UI를 띄우라고 요청
+                backgroundPermission?.let {
+                    onShowRationale {
+                        PermissionUtil.requestPermission(context, backgroundLauncher, backgroundPermission)
+                    }
+                }
+            } else {
+                // 1단계(전경) 실패 -> 최종 실패
+                onPermissionResult(false, false)
+            }
+        }
+
+    // --- 3. 화면이 ON_RESUME 될 때마다 권한 상태를 다시 체크 ---
+    // (사용자가 설정에서 수동으로 권한을 켜고 돌아오는 경우)
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    // 현재 "항상 허용" 상태인지 체크해서 알려줌
+                    onPermissionResult(hasForegroundPermission(), hasBackgroundPermission())
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    // --- 4. 컴포저블이 처음 실행될 때 권한 요청 로직 (1회) ---
+    LaunchedEffect(Unit) {
+        if (hasBackgroundPermission()) {
+            // 이미 "항상 허용" 상태면, 즉시 성공 반환
+            onPermissionResult(true, true)
+            return@LaunchedEffect
+        }
+
+        if (!hasForegroundPermission()) {
+            // 1단계(전경) 권한이 없으므로, 전경 권한부터 요청
+            PermissionUtil.requestPermissions(context, foregroundLauncher, foregroundPermissions)
+            return@LaunchedEffect
+        }
+
+        // 1단계(전경)는 있지만 2단계(백그라운드)가 없는 경우
+        // Rationale(이유) UI를 띄우라고 즉시 요청
+        backgroundPermission?.let {
+            onShowRationale {
+                PermissionUtil.requestPermission(context, backgroundLauncher, backgroundPermission)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/common/util/PermissionHandler.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/common/util/PermissionHandler.kt
@@ -61,7 +61,7 @@ fun PermissionHandler(
             PermissionUtil.hasPermissions(context, permissionsToRequest)
 
         if (!allPermissionsGranted) {
-            PermissionUtil.requestPermission(context, launcher, permissionsToRequest)
+            PermissionUtil.requestPermissions(context, launcher, permissionsToRequest)
         }
     }
 }

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/MapConstants.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/MapConstants.kt
@@ -1,6 +1,10 @@
 package com.dpm.sixpack.presentation.routes.running.map
 
+import android.os.Build
+import com.dpm.sixpack.core.permission.SixPackPermissions
+import com.dpm.sixpack.core.permission.SixPackPermissions.Companion.ForegroundServicePermissions
 import com.dpm.sixpack.core.permission.SixPackPermissions.Companion.LocationPermissions
+import com.dpm.sixpack.core.permission.SixPackPermissions.Companion.NotificationPermissions
 import com.dpm.sixpack.core.permission.SixPackPermissions.Companion.SensorPermissions
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
@@ -19,5 +23,13 @@ object MapConstants {
             DEFAULT_ZOOM,
         )
 
-    val MAP_PERMISSIONS = LocationPermissions + SensorPermissions
+    val MAP_PERMISSIONS =
+        LocationPermissions + SensorPermissions + NotificationPermissions + ForegroundServicePermissions
+
+    val BACKGROUND_PERMISSIONS: List<SixPackPermissions> =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            listOf(SixPackPermissions.BackgroundLocationPermission)
+        } else {
+            emptyList()
+        }
 }

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/MapViewModel.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/MapViewModel.kt
@@ -93,7 +93,10 @@ class MapViewModel @Inject constructor(
             MapIntent.FollowingModeOff -> handleToggleFollowingModeOff()
             is MapIntent.SessionFinish -> handleSessionFinish(intent.mapImage)
             is MapIntent.UpdateUserLocation -> handleUserLocationChange(intent.latLng)
-            is MapIntent.UpdatePermission -> handlePermissionUpdate(intent.isGranted)
+            MapIntent.AllPermissionsGranted -> handleAllPermissionsGranted()
+            MapIntent.PermissionsRejected -> handlePermissionsRejected()
+            is MapIntent.RequestBackgroundPermissionDialog -> handleBackgroundPermissionDialog(true)
+            is MapIntent.DismissBackgroundPermissionDialog -> handleBackgroundPermissionDialog(false)
             is MapIntent.UpdateRunningMapPath -> updateRunningMapPath(intent.pathState)
         }
     }
@@ -147,32 +150,26 @@ class MapViewModel @Inject constructor(
         }
     }
 
-    @RequiresPermission(allOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
-    private fun handlePermissionUpdate(isGranted: Boolean) {
-        if (isGranted) {
-            loadLocationFromClient(
-                onSuccess = { latLng ->
-                    intent {
-                        reduce {
-                            state.copy(
-                                isStartButtonEnabled = true,
-                            )
-                        }
-                        postSideEffect(MapSideEffect.SetCameraPosition(latLng))
-                    }
-                },
-            )
-        } else {
-            intent {
-                reduce {
-                    state.copy(
-                        isStartButtonEnabled = false,
-                    )
-                }
-                postSideEffect(MapSideEffect.SetCameraPosition(MapConstants.DEFAULT_CAMERA_POSITION.target))
+    // 👇 [수정] handleBackgroundPermissionGranted -> handleAllPermissionsGranted
+    private fun handleAllPermissionsGranted() =
+        intent {
+            reduce {
+                state.copy(
+                    showRationaleDialog = false,
+                    allPermissionsGranted = true, // 이름 변경
+                )
             }
         }
-    }
+
+    // 👇 [추가]
+    private fun handlePermissionsRejected() =
+        intent {
+            reduce {
+                state.copy(
+                    allPermissionsGranted = false,
+                )
+            }
+        }
 
     private fun handleSessionStartButtonClick() =
         intent {
@@ -181,7 +178,6 @@ class MapViewModel @Inject constructor(
                     mapViewState = MapViewState.Running(),
                 )
             }
-
             postSideEffect(MapSideEffect.SetBottomBarVisibility(false))
         }
 
@@ -189,11 +185,20 @@ class MapViewModel @Inject constructor(
         intent {
             reduce {
                 state.copy(
-                    isStartButtonEnabled = false,
+                    allPermissionsGranted = false, // 이름 변경
                 )
             }
             postSideEffect(MapSideEffect.SetBottomBarVisibility(true))
             postSideEffect(MapSideEffect.ShowToast(R.string.running_permission_toast))
+        }
+
+    private fun handleBackgroundPermissionDialog(showDialog: Boolean) =
+        intent {
+            reduce {
+                state.copy(
+                    showRationaleDialog = showDialog,
+                )
+            }
         }
 
     // 세션 종료 준비

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/RunningMapScreen.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/RunningMapScreen.kt
@@ -42,10 +42,13 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.dpm.sixpack.core.permission.PermissionUtil
 import com.dpm.sixpack.presentation.R
 import com.dpm.sixpack.presentation.common.components.DoRunDefaultButton
+import com.dpm.sixpack.presentation.common.components.dialog.DialogButtonType
+import com.dpm.sixpack.presentation.common.components.dialog.DoRunDefaultDialog
 import com.dpm.sixpack.presentation.common.model.FriendItem
-import com.dpm.sixpack.presentation.common.util.PermissionHandler
+import com.dpm.sixpack.presentation.common.util.BackgroundPermissionHandler
 import com.dpm.sixpack.presentation.routes.running.map.MapConstants.DEFAULT_ZOOM
 import com.dpm.sixpack.presentation.routes.running.map.MapConstants.FINAL_RESOLUTION
+import com.dpm.sixpack.presentation.routes.running.map.MapConstants.MAP_PERMISSIONS
 import com.dpm.sixpack.presentation.routes.running.map.MapConstants.SNAPSHOT_PADDING
 import com.dpm.sixpack.presentation.routes.running.map.component.DoRunMarker
 import com.dpm.sixpack.presentation.routes.running.map.component.LocationTrackingButton
@@ -103,6 +106,9 @@ internal fun RunningMapScreen(
     val state by mapViewModel.collectAsState()
     val pagingItems = mapViewModel.friendPagingFlow.collectAsLazyPagingItems()
 
+    // 설정으로 이동하는 런처
+    var settingsLauncher by remember { mutableStateOf<(() -> Unit)?>(null) }
+
     mapViewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is MapSideEffect.SetBottomBarVisibility -> {
@@ -130,14 +136,42 @@ internal fun RunningMapScreen(
         }
     }
 
-    PermissionHandler(
+    BackgroundPermissionHandler(
         context = LocalContext.current,
         lifecycleOwner = LocalLifecycleOwner.current,
-        permissionsToRequest = MapConstants.MAP_PERMISSIONS,
-        onPermissionResult = { isGranted ->
-            mapViewModel.onIntent(MapIntent.UpdatePermission(isGranted))
+        foregroundPermissions = MapConstants.MAP_PERMISSIONS,
+        onPermissionResult = { foregroundGranted, backgroundGranted ->
+            // 1단계(전경)와 2단계(백그라운드)가 모두 승인되어야 최종 승인
+            if (foregroundGranted && backgroundGranted) {
+                mapViewModel.onIntent(MapIntent.AllPermissionsGranted)
+            } else {
+                mapViewModel.onIntent(MapIntent.PermissionsRejected)
+            }
+        },
+        onShowRationale = { launchSettings ->
+            settingsLauncher = launchSettings
+            mapViewModel.onIntent(MapIntent.RequestBackgroundPermissionDialog)
         },
     )
+
+    if (state.showRationaleDialog) {
+        DoRunDefaultDialog(
+            title = "위치 권한 안내",
+            subtitle = "러닝기록측정을 위해선 설정에서 위치권한을\n'항상 허용'으로 변경해주세요.",
+            onDismissRequest = {
+                mapViewModel.onIntent(MapIntent.DismissBackgroundPermissionDialog)
+            },
+            onCancelClick = {
+                mapViewModel.onIntent(MapIntent.DismissBackgroundPermissionDialog)
+            },
+            cancelButtonText = "취소",
+            confirmButtonText = "이동",
+            onConfirmClick = {
+                settingsLauncher?.invoke()
+            },
+            confirmButtonType = DialogButtonType.Primary,
+        )
+    }
 
     RunningMapScreenContent(
         modifier = modifier,
@@ -386,17 +420,13 @@ private fun RunningMapScreenContent(
                     )
 
                     RunningStartButton(
-                        enabled = mapState.isStartButtonEnabled,
                         modifier =
                             Modifier.constrainAs(startButtonRef) {
                                 bottom.linkTo(parent.bottom)
                             },
+                        enabled = mapState.allPermissionsGranted,
                         onStartClick = {
-                            if (PermissionUtil.hasPermissions(context, MapConstants.MAP_PERMISSIONS)) {
-                                onMapIntent(MapIntent.SessionStartClick)
-                            } else {
-                                onMapIntent(MapIntent.SessionStartFailed)
-                            }
+                            onMapIntent(MapIntent.SessionStartClick)
                         },
                     )
                 }

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/contract/MapIntent.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/contract/MapIntent.kt
@@ -15,10 +15,6 @@ sealed interface MapIntent : RunningRouteIntent {
         val latLng: LatLng,
     ) : MapIntent
 
-    data class UpdatePermission(
-        val isGranted: Boolean,
-    ) : MapIntent
-
     data object SessionStartFailed : MapIntent
 
     data class UpdateRunningMapPath(
@@ -32,6 +28,19 @@ sealed interface MapIntent : RunningRouteIntent {
     data class SessionFinish(
         val mapImage: Bitmap,
     ) : MapIntent
+
+    // region Permission
+
+    /** 모든 권한 (전경 + 백그라운드)이 최종 승인됨 */
+    data object AllPermissionsGranted : MapIntent
+
+    /** 권한 중 하나라도 최종 거부됨 */
+    data object PermissionsRejected : MapIntent
+
+    data object RequestBackgroundPermissionDialog : MapIntent
+
+    data object DismissBackgroundPermissionDialog : MapIntent
+    // endregion
 
     sealed interface FriendSheetIntent : MapIntent {
         data class ClickFriendItem(

--- a/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/contract/MapUiState.kt
+++ b/presentation/src/main/java/com/dpm/sixpack/presentation/routes/running/map/contract/MapUiState.kt
@@ -9,7 +9,8 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class MapUiState(
     val isFollowingModeEnabled: Boolean = true,
-    val isStartButtonEnabled: Boolean = true,
+    val allPermissionsGranted: Boolean = false,
+    val showRationaleDialog: Boolean = false,
     val mapViewState: MapViewState = MapViewState.Loading,
 ) : RunningRouteUiState
 


### PR DESCRIPTION
## Closed Issue
- closed #102 


## 변경 내용과 목적  

### 백그라운드 위치 권한 추가
안드로이드 11 이상부터 백그라운드 위치(즉 위치권한을 '항상 허용')는 안드로이드에서 제공하는 권한 다이얼로그로 선택을 못합니다.
저희 앱 특성상 백그라운드에서 위치권한을 가지고 있어야 화면이 꺼지거나, 홈화면에 나갔을때에도 UI가 업데이트 되기때문에
해당 권한을 추가하였고,
이로 인해 전체적인 권한 획득 플로우를 수정했습니다.

원래 MainScreen에서 1차적으로 앱의 모든 권한을 요청하도록 넣어놨었고,
2차적으로 지도 화면에서 지도와 러닝에 필요한 권한을 요청하도록 했었는데
너무 복잡해지는것같아 MainScreen의 권한 요청 로직은 빼고 맵에서는 지도와 러닝에 필요한 권한을 요청하고,
위치가 '항상 허용'이 아니면 DoRunDefaultDialog를 띄워 기기 설정으로 이동하게 유도합니다.
백그라운드위치권한을 필요한 러닝에 필요한 모든 권한(포그라운드위치, 노티피케이션, 센서, 포그라운드 서비스)을 허용하지않으면 러닝 시작을 못하게 시작 버튼을 막아두었습니다.


## 🙏 Reviewer 가 신경써서 볼만한 포인트  

화-수 중으로 직접 뛰어보고 잘되는지 한번 더 확인하겠습니다